### PR TITLE
fix: remove ovmf images from qemu

### DIFF
--- a/system/programs/qemu.nix
+++ b/system/programs/qemu.nix
@@ -34,8 +34,9 @@ in
         qemu = {
           package = pkgs.qemu_kvm;
           swtpm.enable = true;
-          ovmf.enable = true;
-          ovmf.packages = [ pkgs.OVMFFull.fd ];
+          # These images comes default with qemu
+          # ovmf.enable = true;
+          # ovmf.packages = [ pkgs.OVMFFull.fd ];
         };
       };
       spiceUSBRedirection.enable = true;


### PR DESCRIPTION
Qemu now comes with all images default