### PR TITLE
cyberpunk theme validates the theme contract

### DIFF
--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -185,10 +185,31 @@ listed above and get exercised as their surfaces land.
 Phase 8 complete (2026-07-06): the framework exists — descriptor registry,
 injected services, themed popouts, tray, Nix bridge, single runtime tree.
 
-## Phase 9 — Second theme (validation) ⬜
+## Phase 9 — Second theme (validation) ✅
 
-One theme only (pokemon or cyberpunk, not both), data-first. Purpose: prove the
+One theme only (cyberpunk chosen over pokemon), data-first. Purpose: prove the
 contract; fix what it breaks.
+
+- ✅ `modules/rice/themes/cyberpunk/_theme.nix` — deliberately data-ONLY
+  manifest: neon token set, Orbitron/Chakra Petch typography, hard radii,
+  snappier motion durations, glyph-only icon overrides, glyph workspace
+  identities, `palette.legacy` bridge entry. Zero asset files, zero plugins.
+- ✅ Contract gap found and fixed (the phase's purpose): `WorkspacesGlance`
+  rendered identity icons only as images, so a data-only theme couldn't
+  express workspace identity. The widget now applies the D-016 heuristic to
+  `settings.items[].icon` — "/" means assetUrl image, anything else is a font
+  glyph tinted with the item's color. Additive, widget-owned schema; no
+  contract text change needed (widget-contract leaves settings widget-defined).
+- ✅ Nix wiring: `cyberpunk` in the `rice.theme` enum; legacy palette entry in
+  `_legacy-palettes.nix`. The stale pre-contract pokemon scaffold (README-only,
+  described a structure the contract replaced) retired along with its dead
+  enum entry and asset-dir options.
+- Verified: both manifests build via `mkThemeManifest`; `rice-lint` clean;
+  shitbox system evals with either theme active (D-012 scheme follows);
+  12s live shell smoke test per theme (`RICE_MANIFEST` dev path) — zero QML
+  errors on both, confirming the glyph arm and the unchanged image arm.
+- Still open (by design): no wallpapers/preview.png yet — those become
+  meaningful with the Phase 10 switcher.
 
 ## Phase 10 — Rice switcher ⬜
 

--- a/modules/rice.nix
+++ b/modules/rice.nix
@@ -8,7 +8,7 @@ _: {
           cfg = config.rice;
           themeType = lib.types.enum [
             "lotm"
-            "pokemon"
+            "cyberpunk"
           ];
         in
         {
@@ -52,14 +52,6 @@ _: {
                 };
               };
 
-              pokemon = {
-                assetsDir = lib.mkOption {
-                  type = lib.types.path;
-                  default = ./rice/themes/pokemon/assets;
-                  example = "./modules/rice/themes/pokemon/assets";
-                  description = "Pokemon theme asset directory.";
-                };
-              };
             };
           };
         };
@@ -72,13 +64,6 @@ _: {
           };
         };
 
-      rice-theme-pokemon =
-        { config, lib, ... }:
-        {
-          config = lib.mkIf (config.rice.enable && config.rice.theme == "pokemon") {
-            # Pokemon-specific settings will be added when this theme is implemented.
-          };
-        };
     };
 
     homeModules = {

--- a/modules/rice/nix/_legacy-palettes.nix
+++ b/modules/rice/nix/_legacy-palettes.nix
@@ -4,4 +4,5 @@
 # _theme.nix — never a duplicated color table.
 {
   lotm = (import ../themes/lotm/_theme.nix).palette.legacy;
+  cyberpunk = (import ../themes/cyberpunk/_theme.nix).palette.legacy;
 }

--- a/modules/rice/runtime/quickshell/widgets/workspaces/WorkspacesGlance.qml
+++ b/modules/rice/runtime/quickshell/widgets/workspaces/WorkspacesGlance.qml
@@ -3,9 +3,11 @@ import "../../core"
 
 // ── WorkspacesGlance ──────────────────────────────────────────
 // Workspace indicator. Identity comes entirely from theme settings:
-//   settings.items = [ { id, label, icon (assetUrl spec), color } ]
-// With empty settings it degrades to a plain numeric readout.
-// Services: hypr (injected).
+//   settings.items = [ { id, label, icon, color } ]
+// icon follows the D-016 heuristic: a value containing "/" is an
+// assetUrl spec (image file / raster output); anything else is a
+// font glyph tinted with the item's color. With empty settings it
+// degrades to a plain numeric readout. Services: hypr (injected).
 
 Item {
     id: root
@@ -34,6 +36,8 @@ Item {
                 required property var modelData
                 readonly property bool isActive: modelData.id === root.active
                 readonly property color wsColor: modelData.color ?? Theme.colors.accent.primary
+                readonly property string iconSpec: modelData.icon ?? ""
+                readonly property bool iconIsImage: Theme.iconIsFile(iconSpec)
 
                 width: 30
                 height: 30
@@ -56,14 +60,30 @@ Item {
                 // Authored color artwork (theme-provided); the widget only
                 // dims inactive entries and rings the active one.
                 Image {
+                    visible: slot.iconIsImage
                     anchors.centerIn: parent
                     width: 24
                     height: 24
-                    source: Theme.assetUrl(slot.modelData.icon ?? "")
+                    source: slot.iconIsImage ? Theme.assetUrl(slot.iconSpec) : ""
                     sourceSize.width: 48
                     sourceSize.height: 48
                     fillMode: Image.PreserveAspectFit
                     smooth: true
+                    opacity: slot.isActive ? 1 : 0.45
+
+                    Behavior on opacity {
+                        MotionAnim {}
+                    }
+                }
+
+                // Glyph identity, tinted with the item's color.
+                Text {
+                    visible: !slot.iconIsImage
+                    anchors.centerIn: parent
+                    text: slot.iconIsImage ? "" : slot.iconSpec
+                    color: slot.wsColor
+                    font.family: Theme.typography.families.mono
+                    font.pointSize: Theme.typography.sizes.icon
                     opacity: slot.isActive ? 1 : 0.45
 
                     Behavior on opacity {

--- a/modules/rice/themes/cyberpunk/README.md
+++ b/modules/rice/themes/cyberpunk/README.md
@@ -1,0 +1,17 @@
+# Cyberpunk Theme
+
+Phase 9 validation theme: deliberately **data-only**. Everything the
+desktop shows comes from `_theme.nix` — tokens, fonts, glyph icon
+overrides, glyph workspace identities, and the D-012 legacy palette.
+No authored artwork, no plugins, no raster pipeline.
+
+Contrast axis vs LOTM (what this theme is meant to stress):
+
+- glyph workspace identities (LOTM: authored PNG emblems)
+- glyph-only icon overrides (LOTM: SVG sigil files)
+- hard radii + shorter motion durations (LOTM: soft + calm)
+- display/sans font swap (Orbitron / Chakra Petch)
+
+`assets/` holds role directories as they become needed (wallpapers,
+preview.png for the Phase 10 switcher). It currently ships no files —
+that is the point.

--- a/modules/rice/themes/cyberpunk/_theme.nix
+++ b/modules/rice/themes/cyberpunk/_theme.nix
@@ -1,0 +1,154 @@
+# Cyberpunk theme manifest source (contracts/theme-manifest.md).
+# Pure data — no behavior. Underscore prefix keeps import-tree from
+# loading it as a flake-parts module; the rice-manifest HM module
+# imports it explicitly and serializes it to JSON.
+#
+# Phase 9 validation theme (ROADMAP): deliberately data-ONLY — no
+# authored artwork, identity carried entirely by tokens, fonts, and
+# Nerd Font glyphs — to prove a theme needs nothing but a manifest.
+let
+  bg = {
+    base = "#0b0f1a"; # night city black-blue
+    mantle = "#080b13";
+    sunken = "#05070d";
+    elevated = "#141b2b";
+    surface1 = "#1e2940";
+    surface2 = "#2a3956";
+  };
+  fg = {
+    primary = "#d6e5ff"; # ice
+    muted = "#93a7c8";
+    subtle = "#5f7194";
+  };
+  accent = {
+    primary = "#00e5ff"; # neon cyan
+    secondary = "#ff2ec4"; # hot magenta
+    tertiary = "#f5d90a"; # warning-tape yellow
+  };
+  state = {
+    ok = "#3ddc97";
+    warn = "#ffb020";
+    danger = "#ff4d6d";
+    info = "#4dc9ff";
+  };
+
+  # "#rrggbb" → "rrggbb" for the legacy palette key space.
+  strip = c: builtins.substring 1 6 c;
+in
+{
+  meta = {
+    name = "cyberpunk";
+    displayName = "Cyberpunk";
+    version = "0.1.0";
+    schemaVersion = 2;
+  };
+
+  tokens = {
+    colors = { inherit bg fg accent state; };
+
+    typography = {
+      families = {
+        display = "Orbitron";
+        sans = "Chakra Petch";
+        mono = "JetBrainsMono Nerd Font";
+      };
+      sizes = {
+        small = 10;
+        body = 13;
+        bar = 14;
+        heading = 18;
+        icon = 18;
+      };
+    };
+
+    metrics = {
+      # Hard edges: near-zero radii are the theme's silhouette.
+      radius = {
+        small = 2;
+        medium = 4;
+        large = 8;
+      };
+      space = {
+        xs = 4;
+        sm = 8;
+        md = 12;
+        lg = 16;
+      };
+      bar = {
+        height = 48;
+        margin = 6;
+        spacing = 10;
+        opacity = 0.92;
+      };
+    };
+
+    motion = {
+      # Snappier than LOTM across the board — the theme's tempo.
+      durations = {
+        fast = 110;
+        base = 190;
+        slow = 300;
+        overlay = 80;
+      };
+      enabled = true;
+    };
+  };
+
+  assets = {
+    # root is set by mkThemeManifest. Glyph-only overrides (D-016):
+    # no value contains "/", so this theme ships zero icon files.
+    icons = {
+      settings = "";
+      monitor = "󰍹";
+      power = "⏻";
+    };
+  };
+
+  # Per-widget configuration (contracts/widget-contract.md tier 2).
+  # Workspace identity as pure glyph data — exercises the glyph arm
+  # of the identity contract (LOTM exercises the image arm).
+  widgets = {
+    workspaces.settings.items = [
+      { id = 1; label = "Deck"; icon = "󰆍"; color = "#00e5ff"; }
+      { id = 2; label = "Grid"; icon = "󰖟"; color = "#4dc9ff"; }
+      { id = 3; label = "Forge"; icon = "󰅩"; color = "#7aa2ff"; }
+      { id = 4; label = "Link"; icon = "󰭹"; color = "#9d5cff"; }
+      { id = 5; label = "Feed"; icon = "󰝚"; color = "#c44dff"; }
+      { id = 6; label = "Core"; icon = "󰒋"; color = "#ff2ec4"; }
+      { id = 7; label = "Void"; icon = "󰇘"; color = "#ff6b9d"; }
+    ];
+  };
+
+  # Legacy palette bridge (D-012): fills the repo's classic palette
+  # key space so GTK/Qt/hyprlock/Hyprland recolor from this theme.
+  # Accent trick (as in LOTM): the style defaults reference
+  # mauve/blue/sapphire — mapped here to cyan/magenta/yellow.
+  palette.legacy = {
+    base = strip bg.base;
+    mantle = strip bg.mantle;
+    crust = strip bg.sunken;
+    surface0 = strip bg.elevated;
+    surface1 = strip bg.surface1;
+    surface2 = strip bg.surface2;
+    text = strip fg.primary;
+    subtext1 = "b4c6e4";
+    subtext0 = strip fg.muted;
+    overlay2 = "7d8fb0";
+    overlay1 = strip fg.subtle;
+    overlay0 = "4a5a78";
+    red = strip state.danger;
+    green = strip state.ok;
+    yellow = strip state.warn;
+    blue = strip accent.secondary;
+    mauve = strip accent.primary;
+    sapphire = strip accent.tertiary;
+    sky = strip state.info;
+    maroon = "d13a57";
+    peach = "ff9e64";
+    teal = "2fd6c4";
+    lavender = "9d5cff";
+    pink = "ff6b9d";
+    flamingo = "ff8fab";
+    rosewater = "ffc9d4";
+  };
+}

--- a/modules/rice/themes/cyberpunk/assets/README.md
+++ b/modules/rice/themes/cyberpunk/assets/README.md
@@ -1,0 +1,6 @@
+# Cyberpunk Assets
+
+Role directories land here when the theme grows files (wallpapers/,
+preview.png). The theme is currently glyph-only by design — see the
+theme README. This file exists so the assets root is a valid store
+path for `mkThemeManifest`.

--- a/modules/rice/themes/pokemon/README.md
+++ b/modules/rice/themes/pokemon/README.md
@@ -1,9 +1,0 @@
-# Pokemon Theme Scaffold
-
-This theme should stay structurally independent from LOTM.
-
-Planned files:
-
-- `default.nix`: entrypoint for Pokemon theme config.
-- `hyprland.nix`: workspace and binds for Pokemon semantics.
-- `quickshell.nix`: runtime JSON generation for Pokemon UI.

--- a/modules/rice/themes/pokemon/assets/README.md
+++ b/modules/rice/themes/pokemon/assets/README.md
@@ -1,3 +1,0 @@
-# Pokemon Assets
-
-All Pokemon-specific assets should live in this directory.


### PR DESCRIPTION
Data-only second theme: neon tokens, Orbitron/Chakra Petch, glyph workspace identities, D-012 legacy palette. Contract gap fixed: WorkspacesGlance now renders glyph identity icons via the D-016 file-vs-glyph heuristic (LOTM image arm unchanged). Stale pokemon scaffold retired; cyberpunk added to the rice.theme enum.

Verified: both manifests build, rice-lint clean, shitbox evals with either theme, 12s live smoke test per theme with zero QML errors.