### PR TITLE
Feature/phase10 rice switcher

### DIFF
--- a/.claude/skills/theme-authoring.md
+++ b/.claude/skills/theme-authoring.md
@@ -22,7 +22,8 @@ manifest (`theme.nix`), tokens, assets, widget configuration, plugin packaging.
   fill every `tokens.*` key; put theme-specific extras under `palette.*`,
   `assets.art.*`, and `widgets.<id>.settings`.
 - Assets are organized by role (`wallpapers/`, `icons/`, `art/`, `sounds/`),
-  `snake_case` filenames, plus a mandatory `preview.png`. Raster variants are
+  `snake_case` filenames. `assets/preview.png` is optional — the index build
+  derives a token-swatch preview when absent (D-018). Raster variants are
   derived from SVG by the build, not committed by hand (D-011).
 - Theme identity flows through tokens, assets, fonts, and settings — e.g. the
   workspace indicator's icon set, labels, and per-workspace colors are

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -82,9 +82,11 @@ theme plugins → {core, components, utils} + injected services only
    methods ([service-contract](contracts/service-contract.md)).
 2. **Shell UI state** — `core/ShellState.qml`: active popout, launcher visibility,
    OSD queue, debug overlay.
-3. **User prefs** — `$XDG_STATE_HOME/rice/` (active-theme pointer + `prefs.json`),
-   accessed only by a `PrefsState` service. Nix defines defaults; state files hold
-   user drift; nothing else is mutable.
+3. **User prefs** — `$XDG_STATE_HOME/rice/`. The active-theme pointer is written
+   only by `rice-switch` and read/watched by `core/ManifestLoader` as manifest-
+   resolution input (D-018); `prefs.json` (future) is accessed only by a
+   `PrefsState` service. Nix defines defaults; state files hold user drift;
+   nothing else is mutable.
 
 ## Event flow
 

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -185,6 +185,31 @@ Status values: `active` | `superseded by D-NNN`.
   authored art. The raster pipeline remains for true silhouette/derivable
   cases.
 
+### D-018 — Switch machinery concretized (index, pointer, preview)
+
+- Date: 2026-07-06 · Status: active
+- The D-003 two-layer switch is realized as: `mkThemeIndex` builds EVERY theme
+  under `modules/rice/themes/` and installs `~/.config/rice/themes.json`
+  (`{ schemaVersion, default, themes.<name> = { displayName, manifest, preview,
+  wallpapers } }`, store paths). The mutable pointer `$XDG_STATE_HOME/rice/active`
+  holds a theme name; it is written ONLY by `rice-switch` (atomic rename +
+  wallpaper orchestration + IPC nudge `rice reload`). Runtime resolution order:
+  `$RICE_MANIFEST` env → pointer via index → `~/.config/rice/manifest.json`
+  (Nix-default theme).
+- The pointer is read and watched by `core/ManifestLoader` — it is manifest-
+  resolution input, not a user pref. This narrows the ARCHITECTURE note that
+  `$XDG_STATE_HOME/rice/` is "accessed only by a PrefsState service": that rule
+  now covers `prefs.json` (still future); text updated in the same commit.
+- Previews: not a manifest field (contract's `meta.preview` removed before any
+  theme used it, D-013 procedure). A theme MAY ship authored
+  `assets/preview.png` (D-017 — authored art wins); otherwise the index build
+  derives a swatch card from the theme's own tokens (D-011 — derived variants
+  are built, never hand-maintained). Every index entry therefore always has a
+  preview.
+- Why: switching must work with zero eval at switch time (index carries
+  everything `rice-switch` and the switcher UI need), and no theme should be
+  blocked on producing screenshot art before it can appear in the switcher.
+
 ---
 
 ## Legacy imports

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -238,12 +238,40 @@ contract; fix what it breaks.
   rejected; switcher screenshot confirms themed cards + active ring.
 - Requires a rebuild to land on the host (themes.json, rice-switch, keybind).
 
+## Phase 11 — Per-theme wallpapers + wallpaper switcher ⬜
+
+Each rice owns its wallpaper set; browsing/cycling stays inside the active
+theme's set. Builds on machinery that already anticipates it: the D-018 index
+carries `wallpapers` per theme, `rice-switch` applies the first entry, and
+`WallpaperState.setWallpaper` (Phase 5) still has no UI caller.
+
+- Themes ship `assets/wallpapers/` (role dir per theme-authoring skill) and
+  list them in manifest `assets.wallpapers` — both LOTM and cyberpunk need
+  real files before any UI makes sense. Consider directory-globbing in
+  `mkThemeManifest` so themes don't hand-list every file.
+- Wallpaper switcher surface (`modules/wallpapers/`): grid of the ACTIVE
+  theme's wallpapers (from the manifest via `Theme`), current one marked,
+  click applies via injected/imported `WallpaperState` — first real caller of
+  that command path. Open/close like other center-stage surfaces (IPC +
+  keybind, Esc, click-outside, Motion specs).
+- Cycling: `next()` command (surface button + IPC `wallpapers next`, optional
+  keybind) stepping through the active theme's list — never across themes.
+- Per-theme wallpaper memory: remember the last-used wallpaper per theme in
+  `$XDG_STATE_HOME/rice/prefs.json` so switching rice restores *that* theme's
+  wallpaper, not just `wallpapers[0]`. This concretizes the `PrefsState`
+  service (ARCHITECTURE state category 3) and upgrades rice-switch's
+  orchestration from "first entry" to "last used, else first". Who reads
+  prefs.json at switch time (rice-switch via jq vs PrefsState in-shell) is a
+  design decision for the phase — keep one writer.
+- Exit: each theme cycles only its own wallpapers; a rice switch restores the
+  theme's remembered wallpaper; zero hardcoded paths outside theme manifests.
+
 ## Later surfaces (slot in after Phase 6, order by appetite)
 
 Volume/brightness OSDs · media controls (MprisState) · power menu · clipboard
-history · wallpaper picker · dashboard widgets (system monitor, weather, dev
-widgets) · optional dock · LOTM plugin widgets (tarot/ritual — proves the plugin
-contract) · ambient effects tier (Phase 4+ of `contracts/motion-contract.md`).
+history · dashboard widgets (system monitor, weather, dev widgets) · optional
+dock · LOTM plugin widgets (tarot/ritual — proves the plugin contract) ·
+ambient effects tier (Phase 4+ of `contracts/motion-contract.md`).
 
 ## Deferred / future
 

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -211,11 +211,32 @@ contract; fix what it breaks.
 - Still open (by design): no wallpapers/preview.png yet — those become
   meaningful with the Phase 10 switcher.
 
-## Phase 10 — Rice switcher ⬜
+## Phase 10 — Rice switcher ✅
 
-- Two-layer switch machinery (D-003): all-themes build + `themes.json` index,
-  `$XDG_STATE_HOME/rice/active` pointer, `rice-switch` tool, live re-bind,
-  wallpaper orchestration, switcher UI with `preview.png`.
+- Two-layer switch machinery (D-003), concretized as D-018:
+- ✅ `mkThemeIndex` (`modules/rice/nix/_index-lib.nix`): builds every theme
+  under `themes/`, installs `~/.config/rice/themes.json` (displayName,
+  manifest, preview, wallpapers per theme — all store paths). Previews:
+  authored `assets/preview.png` wins; otherwise a token-swatch card is
+  derived at build with ImageMagick (D-011). `meta.preview` removed from the
+  contract before any theme used it.
+- ✅ `rice-switch` (`modules/rice/nix/switch.nix`): validates against the
+  index, atomic pointer write to `$XDG_STATE_HOME/rice/active`, wallpaper
+  orchestration (first theme wallpaper via the shared awww flow — dormant
+  until themes ship wallpapers), IPC nudge `rice reload` for the
+  pointer-file-creation case.
+- ✅ Live re-bind: `ManifestLoader` resolves `$RICE_MANIFEST` → pointer via
+  index → default `manifest.json`, watching all three files; IPC
+  `rice active` exposes the resolved theme for scripting/tests.
+- ✅ Switcher UI: `modules/switcher/ThemeSwitcher.qml` — preview cards from
+  `Theme.catalog`, active ringed, click switches via new `RiceState` service
+  (runs rice-switch; pointer/index knowledge stays in core). Super+T /
+  `shell toggleSwitcher`; mutually exclusive with launcher/dashboard.
+- Verified: index + previews build; home generation builds; rice-lint clean;
+  sandboxed-HOME live test — shell resolves pointer at startup, `rice-switch`
+  re-binds the running shell via the file watch alone (<2s), bogus names
+  rejected; switcher screenshot confirms themed cards + active ring.
+- Requires a rebuild to land on the host (themes.json, rice-switch, keybind).
 
 ## Later surfaces (slot in after Phase 6, order by appetite)
 

--- a/docs/architecture/contracts/theme-manifest.md
+++ b/docs/architecture/contracts/theme-manifest.md
@@ -19,7 +19,8 @@ exclusively through the `Theme` facade.
     displayName = "…";            # required, shown in the switcher
     version = "0.1.0";            # required
     schemaVersion = 2;            # required
-    preview = ./preview.png;      # required, used by the rice switcher
+    # switcher preview is NOT a manifest field (D-018): ship authored
+    # assets/preview.png, or the index build derives a token swatch.
   };
 
   tokens = {                      # CLOSED schema — every key required unless marked optional

--- a/modules/rice/nix/_index-lib.nix
+++ b/modules/rice/nix/_index-lib.nix
@@ -1,0 +1,64 @@
+# mkThemeIndex — builds EVERY theme under modules/rice/themes/ and
+# writes the themes.json index the switch machinery reads (D-003,
+# D-018). Each entry carries the validated manifest store path, a
+# preview image, and the theme's wallpaper list so rice-switch can
+# orchestrate wallpapers without evaluating Nix at switch time.
+#
+# Preview resolution (D-018): an authored assets/preview.png wins
+# (authored art is source, D-017); otherwise a swatch card is
+# derived from the theme's own tokens at build time (D-011 — never
+# hand-maintained).
+{ pkgs, lib }:
+{ defaultTheme }:
+let
+  themesDir = ../themes;
+  mkThemeManifest = import ./_manifest-lib.nix { inherit pkgs lib; };
+
+  themeNames = lib.attrNames (lib.filterAttrs
+    (name: type: type == "directory" && builtins.pathExists (themesDir + "/${name}/_theme.nix"))
+    (builtins.readDir themesDir));
+
+  swatchPreview = name: tokens:
+    let c = tokens.colors; in
+    pkgs.runCommand "rice-preview-${name}.png"
+      { nativeBuildInputs = [ pkgs.imagemagick ]; } ''
+      magick -size 320x180 xc:'${c.bg.base}' \
+        -fill '${c.bg.elevated}' -draw 'roundrectangle 16,16 304,110 6,6' \
+        -fill '${c.bg.surface1}' -draw 'roundrectangle 16,124 304,140 3,3' \
+        -fill '${c.accent.primary}'   -draw 'roundrectangle 16,150 110,164 3,3' \
+        -fill '${c.accent.secondary}' -draw 'roundrectangle 118,150 212,164 3,3' \
+        -fill '${c.accent.tertiary}'  -draw 'roundrectangle 220,150 304,164 3,3' \
+        -fill '${c.fg.primary}' -draw 'roundrectangle 32,32 180,44 3,3' \
+        -fill '${c.fg.muted}'   -draw 'roundrectangle 32,56 240,64 2,2' \
+        -fill '${c.fg.subtle}'  -draw 'roundrectangle 32,76 210,84 2,2' \
+        $out
+    '';
+
+  entry = name:
+    let
+      themeDir = themesDir + "/${name}";
+      built = mkThemeManifest { themeName = name; inherit themeDir; };
+      authored = themeDir + "/assets/preview.png";
+    in
+    {
+      displayName = built.manifest.meta.displayName or name;
+      manifest = "${built.json}";
+      preview =
+        if builtins.pathExists authored
+        then "${authored}"
+        else "${swatchPreview name built.manifest.tokens}";
+      wallpapers = built.manifest.assets.wallpapers or [ ];
+    };
+
+  index = {
+    schemaVersion = 1;
+    default = defaultTheme;
+    themes = lib.genAttrs themeNames entry;
+  };
+in
+assert lib.assertMsg (lib.elem defaultTheme themeNames)
+  "rice: default theme '${defaultTheme}' has no package under modules/rice/themes/";
+{
+  inherit index;
+  json = pkgs.writeText "rice-themes-index.json" (builtins.toJSON index);
+}

--- a/modules/rice/nix/manifest.nix
+++ b/modules/rice/nix/manifest.nix
@@ -1,12 +1,16 @@
-# Installs the active theme's validated manifest at the runtime's
-# manifest path (~/.config/rice/manifest.json). Validation and the
-# raster pipeline live in _manifest-lib.nix (mkThemeManifest).
+# Installs the Nix-default theme's validated manifest at the
+# runtime's fallback path (~/.config/rice/manifest.json) and the
+# all-themes index (~/.config/rice/themes.json) the switch
+# machinery reads (D-003, D-018). Validation and the raster
+# pipeline live in _manifest-lib.nix; index assembly and preview
+# derivation in _index-lib.nix.
 _: {
   flake.homeModules.rice-manifest =
     { lib, pkgs, osConfig, ... }:
     let
       cfg = osConfig.rice or { enable = false; };
       mkThemeManifest = import ./_manifest-lib.nix { inherit pkgs lib; };
+      mkThemeIndex = import ./_index-lib.nix { inherit pkgs lib; };
     in
     {
       config = lib.mkIf (cfg.enable or false) {
@@ -14,6 +18,8 @@ _: {
           themeName = cfg.theme;
           themeDir = ../themes + "/${cfg.theme}";
         }).json;
+        xdg.configFile."rice/themes.json".source =
+          (mkThemeIndex { defaultTheme = cfg.theme; }).json;
       };
     };
 }

--- a/modules/rice/nix/switch.nix
+++ b/modules/rice/nix/switch.nix
@@ -1,0 +1,74 @@
+# rice-switch — layer 2 of the theme switch (D-003, D-018): mutates
+# the $XDG_STATE_HOME/rice/active pointer against the Nix-built
+# themes.json index. Layer 1 (building all themes + index) lives in
+# manifest.nix/_index-lib.nix. The shell re-binds live by watching
+# the pointer; the IPC nudge only covers the pointer-file-created
+# case, which file watching can miss.
+_: {
+  flake.homeModules.rice-switch =
+    { lib, pkgs, osConfig, ... }:
+    let
+      cfg = osConfig.rice or { enable = false; };
+
+      rice-switch = pkgs.writeShellScriptBin "rice-switch" ''
+        set -euo pipefail
+
+        jq=${pkgs.jq}/bin/jq
+        index="$HOME/.config/rice/themes.json"
+        state_dir="''${XDG_STATE_HOME:-$HOME/.local/state}/rice"
+        pointer="$state_dir/active"
+
+        [ -r "$index" ] || { echo "rice-switch: no theme index at $index (rebuild with rice.enable)" >&2; exit 1; }
+
+        active() {
+          if [ -r "$pointer" ]; then cat "$pointer"; else "$jq" -r '.default' "$index"; fi
+        }
+
+        list() {
+          local cur; cur="$(active)"
+          "$jq" -r '.themes | to_entries[] | "\(.key)\t\(.value.displayName)"' "$index" |
+            while IFS=$'\t' read -r name display; do
+              if [ "$name" = "$cur" ]; then marker="*"; else marker=" "; fi
+              printf '%s %-12s %s\n' "$marker" "$name" "$display"
+            done
+        }
+
+        case "''${1:-}" in
+          ""|-h|--help)
+            echo "Usage: rice-switch <theme> | --list"; list; exit 0 ;;
+          -l|--list)
+            list; exit 0 ;;
+        esac
+
+        theme="$1"
+        "$jq" -e --arg n "$theme" '.themes[$n]' "$index" >/dev/null || {
+          echo "rice-switch: unknown theme '$theme'" >&2; list >&2; exit 1
+        }
+
+        # Atomic pointer write: the shell watches this file (live re-bind).
+        mkdir -p "$state_dir"
+        printf %s "$theme" > "$pointer.tmp" && mv "$pointer.tmp" "$pointer"
+
+        # Wallpaper orchestration: first theme wallpaper, same awww flow
+        # and persist file as WallpaperState / wallpaper-restore. Themes
+        # without wallpapers keep the current one.
+        wp="$("$jq" -r --arg n "$theme" '.themes[$n].wallpapers[0] // empty' "$index")"
+        if [ -n "$wp" ] && [ -r "$wp" ] && command -v awww >/dev/null; then
+          awww img "$wp" --transition-type fade --transition-duration 1.0 --transition-fps 60 &&
+            mkdir -p "$HOME/.config/wallpaper" &&
+            printf %s "$wp" > "$HOME/.config/wallpaper/current" || true
+        fi
+
+        # Nudge a running shell in case the pointer file was just created
+        # (a watch set on a missing file does not always fire on creation).
+        quickshell -c rice ipc call rice reload >/dev/null 2>&1 || true
+
+        echo "rice-switch: active theme → $theme"
+      '';
+    in
+    {
+      config = lib.mkIf (cfg.enable or false) {
+        home.packages = [ rice-switch ];
+      };
+    };
+}

--- a/modules/rice/runtime/quickshell/core/ManifestLoader.qml
+++ b/modules/rice/runtime/quickshell/core/ManifestLoader.qml
@@ -4,13 +4,17 @@ import Quickshell
 import Quickshell.Io
 
 // ── ManifestLoader ────────────────────────────────────────────
-// The ONLY file that reads theme manifest JSON. Everything else
+// The ONLY file that reads theme manifest JSON, the themes.json
+// index, and the active-theme pointer (D-018). Everything else
 // goes through the Theme facade.
 //
-// Path resolution: $RICE_MANIFEST env override (dev loop) →
-// ~/.config/rice/manifest.json (installed by the rice-manifest HM
-// module). The file is watched: editing the manifest re-themes the
-// running shell live.
+// Path resolution (D-003 two-layer switch):
+//   $RICE_MANIFEST env override (dev loop)
+//   → $XDG_STATE_HOME/rice/active pointer resolved via the
+//     ~/.config/rice/themes.json index
+//   → ~/.config/rice/manifest.json (Nix-default theme).
+// Pointer, index, and manifest are all watched: rice-switch (or a
+// manifest edit) re-themes the running shell live.
 //
 // Runtime defaults below are theme-NEUTRAL. The manifest is
 // deep-merged over them, so `tokens` and `icons` are always
@@ -89,11 +93,39 @@ Item {
     readonly property var icons: manifest.assets.icons
     readonly property string assetsRoot: manifest.assets.root
 
+    // ── Switch machinery (D-003/D-018) ────────────────────────
+    // themes.json index (Nix-built) + mutable active pointer.
+    property var themesIndex: ({})       // name → { displayName, manifest, preview, wallpapers }
+    property string defaultTheme: ""
+    property string pointerName: ""
+
+    readonly property string activeTheme: {
+        if (pointerName.length > 0 && themesIndex[pointerName] !== undefined)
+            return pointerName;
+        return defaultTheme;
+    }
+
+    readonly property string statePath: {
+        const env = Quickshell.env("XDG_STATE_HOME");
+        return (env && env.length > 0 ? env : Quickshell.env("HOME") + "/.local/state") + "/rice/active";
+    }
+
     readonly property string manifestPath: {
         const env = Quickshell.env("RICE_MANIFEST");
         if (env && env.length > 0)
             return env;
+        const entry = themesIndex[activeTheme];
+        if (entry && entry.manifest)
+            return entry.manifest;
         return Quickshell.env("HOME") + "/.config/rice/manifest.json";
+    }
+
+    // rice-switch nudges this after writing the pointer: a watch set
+    // on a not-yet-existing pointer file does not fire on creation.
+    function reload() {
+        indexFile.reload();
+        pointerFile.reload();
+        file.reload();
     }
 
     function _merge(base, over) {
@@ -127,5 +159,43 @@ Item {
         onLoaded: loader._apply(file.text())
         onLoadFailed: console.info("ManifestLoader: no manifest at", loader.manifestPath, "— using runtime defaults")
         onFileChanged: file.reload()
+    }
+
+    FileView {
+        id: indexFile
+        path: Quickshell.env("HOME") + "/.config/rice/themes.json"
+        watchChanges: true
+        onLoaded: {
+            try {
+                const idx = JSON.parse(text());
+                loader.themesIndex = idx.themes ?? {};
+                loader.defaultTheme = idx.default ?? "";
+            } catch (e) {
+                console.warn("ManifestLoader: invalid themes.json:", e);
+            }
+        }
+        onLoadFailed: console.info("ManifestLoader: no themes.json — switch machinery inactive")
+        onFileChanged: reload()
+    }
+
+    FileView {
+        id: pointerFile
+        path: loader.statePath
+        watchChanges: true
+        onLoaded: loader.pointerName = text().trim()
+        onLoadFailed: loader.pointerName = ""
+        onFileChanged: reload()
+    }
+
+    IpcHandler {
+        target: "rice"
+
+        function reload(): void {
+            loader.reload();
+        }
+        // Scripting/testing: `quickshell -c rice ipc call rice active`
+        function active(): string {
+            return loader.activeTheme;
+        }
     }
 }

--- a/modules/rice/runtime/quickshell/core/ShellState.qml
+++ b/modules/rice/runtime/quickshell/core/ShellState.qml
@@ -15,6 +15,7 @@ Item {
     property bool topBarVisible: true
     property bool launcherOpen: false
     property bool dashboardOpen: false
+    property bool switcherOpen: false
     property bool notificationsOpen: false
     property bool osdVisible: false
     property bool debugVisible: false
@@ -32,6 +33,7 @@ Item {
     // Center-stage surfaces are mutually exclusive.
     function openLauncher() {
         dashboardOpen = false;
+        switcherOpen = false;
         activePopout = "";
         launcherOpen = true;
     }
@@ -44,7 +46,17 @@ Item {
 
     function toggleDashboard() {
         launcherOpen = false;
+        switcherOpen = false;
         dashboardOpen = !dashboardOpen;
+    }
+    function toggleSwitcher() {
+        launcherOpen = false;
+        dashboardOpen = false;
+        activePopout = "";
+        switcherOpen = !switcherOpen;
+    }
+    function closeSwitcher() {
+        switcherOpen = false;
     }
     function toggleNotifications() {
         notificationsOpen = !notificationsOpen;
@@ -67,6 +79,9 @@ Item {
         }
         function toggleDashboard(): void {
             shell.toggleDashboard();
+        }
+        function toggleSwitcher(): void {
+            shell.toggleSwitcher();
         }
         function toggleNotifications(): void {
             shell.toggleNotifications();

--- a/modules/rice/runtime/quickshell/core/Theme.qml
+++ b/modules/rice/runtime/quickshell/core/Theme.qml
@@ -135,4 +135,17 @@ QtObject {
     function widgetConfig(widgetId) {
         return ManifestLoader.manifest.widgets[widgetId] ?? ({});
     }
+
+    // ── Theme catalog (switch machinery, D-018) ───────────────
+    // Every Nix-built theme from the themes.json index; empty when
+    // the index is absent (dev run without a rebuild).
+    readonly property string activeName: ManifestLoader.activeTheme
+    readonly property var catalog: {
+        const idx = ManifestLoader.themesIndex;
+        return Object.keys(idx).sort().map(n => ({
+            name: n,
+            displayName: idx[n].displayName ?? n,
+            preview: idx[n].preview ? "file://" + idx[n].preview : ""
+        }));
+    }
 }

--- a/modules/rice/runtime/quickshell/modules/switcher/ThemeSwitcher.qml
+++ b/modules/rice/runtime/quickshell/modules/switcher/ThemeSwitcher.qml
@@ -1,0 +1,194 @@
+import Quickshell
+import Quickshell.Wayland
+import QtQuick
+import "../../core"
+import "../../services/hypr"
+import "../../services/rice"
+
+// ── ThemeSwitcher ─────────────────────────────────────────────
+// Rice switcher (D-003): one card per Nix-built theme from the
+// index (preview + display name), active theme ringed. Click
+// switches via RiceState → rice-switch; the shell re-themes live
+// through the pointer watch, so the open switcher itself recolors.
+// Opens/closes via ShellState (IPC / keybind), Esc, click-outside.
+// Shows only on the focused monitor (HyprState).
+
+PanelWindow {
+    id: switcher
+
+    required property var modelData
+    screen: modelData
+
+    readonly property bool onFocusedScreen: !HyprState.available || HyprState.focusedScreenName === switcher.screen.name
+    readonly property bool open: ShellState.switcherOpen && onFocusedScreen
+
+    // Stay mapped through the fade-out so closing is smooth.
+    visible: open || panel.opacity > 0.01
+
+    WlrLayershell.namespace: "rice-switcher"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: open ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+
+    anchors {
+        top: true
+        bottom: true
+        left: true
+        right: true
+    }
+    color: "transparent"
+
+    component ThemeCard: Rectangle {
+        required property var modelData
+
+        readonly property bool isActive: modelData.name === Theme.activeName
+
+        width: 200
+        height: 158
+        radius: Theme.metrics.radius.medium
+        color: cardMouse.containsMouse ? Theme.colors.bg.elevated : "transparent"
+        border.width: isActive ? 2 : 1
+        border.color: isActive ? Theme.colors.accent.primary : Theme.colors.bg.surface1
+
+        Column {
+            anchors.centerIn: parent
+            spacing: Theme.metrics.space.sm
+
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: 176
+                height: 99
+                radius: Theme.metrics.radius.small
+                color: Theme.colors.bg.sunken
+                clip: true
+
+                Image {
+                    anchors.fill: parent
+                    source: modelData.preview
+                    sourceSize.width: 352
+                    fillMode: Image.PreserveAspectCrop
+                    smooth: true
+                }
+            }
+
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: modelData.displayName
+                color: isActive ? Theme.colors.accent.primary : Theme.colors.fg.primary
+                font.family: Theme.typography.families.sans
+                font.pointSize: Theme.typography.sizes.body
+            }
+        }
+
+        MouseArea {
+            id: cardMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            enabled: !RiceState.busy
+            onClicked: {
+                if (!isActive)
+                    RiceState.switchTo(modelData.name);
+            }
+        }
+    }
+
+    // Scrim: dims the workspace, closes on click-outside.
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.colors.bg.sunken
+        opacity: switcher.open ? 0.45 : 0
+
+        Behavior on opacity {
+            MotionAnim {
+                spec: switcher.open ? Motion.panelOpen : Motion.panelClose
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: ShellState.closeSwitcher()
+        }
+    }
+
+    FocusScope {
+        anchors.fill: parent
+        focus: true
+        Keys.onEscapePressed: ShellState.closeSwitcher()
+
+        Rectangle {
+            id: panel
+
+            anchors.centerIn: parent
+            width: row.width + Theme.metrics.space.lg * 2
+            height: title.height + row.height + status.height + Theme.metrics.space.lg * 3
+            radius: Theme.metrics.radius.large
+            color: Theme.colors.bg.mantle
+            border.width: 1
+            border.color: Theme.colors.bg.surface1
+
+            opacity: switcher.open ? 1 : 0
+            scale: switcher.open ? 1 : 0.94
+
+            Behavior on opacity {
+                MotionAnim {
+                    spec: switcher.open ? Motion.panelOpen : Motion.panelClose
+                }
+            }
+            Behavior on scale {
+                MotionAnim {
+                    spec: switcher.open ? Motion.panelOpen : Motion.panelClose
+                }
+            }
+
+            // Absorb clicks so they don't fall through to the scrim.
+            MouseArea {
+                anchors.fill: parent
+            }
+
+            Text {
+                id: title
+                anchors.top: parent.top
+                anchors.topMargin: Theme.metrics.space.lg
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: "Themes"
+                color: Theme.colors.fg.subtle
+                font.family: Theme.typography.families.display
+                font.pointSize: Theme.typography.sizes.heading
+            }
+
+            Row {
+                id: row
+                anchors.top: title.bottom
+                anchors.topMargin: Theme.metrics.space.lg
+                anchors.horizontalCenter: parent.horizontalCenter
+                spacing: Theme.metrics.space.md
+
+                Repeater {
+                    model: Theme.catalog
+                    ThemeCard {}
+                }
+
+                // Index missing (dev run without rebuild): say so
+                // instead of rendering an empty shell.
+                Text {
+                    visible: Theme.catalog.length === 0
+                    text: "no theme index — rebuild with rice.enable"
+                    color: Theme.colors.fg.muted
+                    font.family: Theme.typography.families.mono
+                    font.pointSize: Theme.typography.sizes.body
+                }
+            }
+
+            Text {
+                id: status
+                anchors.top: row.bottom
+                anchors.topMargin: Theme.metrics.space.sm
+                anchors.horizontalCenter: parent.horizontalCenter
+                height: implicitHeight
+                text: RiceState.busy ? "switching…" : RiceState.error
+                color: RiceState.error.length > 0 ? Theme.colors.state.danger : Theme.colors.fg.subtle
+                font.family: Theme.typography.families.mono
+                font.pointSize: Theme.typography.sizes.small
+            }
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/modules/switcher/qmldir
+++ b/modules/rice/runtime/quickshell/modules/switcher/qmldir
@@ -1,0 +1,1 @@
+ThemeSwitcher 1.0 ThemeSwitcher.qml

--- a/modules/rice/runtime/quickshell/services/rice/RiceState.qml
+++ b/modules/rice/runtime/quickshell/services/rice/RiceState.qml
@@ -1,0 +1,40 @@
+pragma Singleton
+import QtQuick
+import Quickshell.Io
+
+// ── RiceState — REAL ──────────────────────────────────────────
+// Executes theme switches through rice-switch (D-003 layer 2: the
+// tool owns pointer write + wallpaper orchestration; this service
+// never touches those directly). Which themes exist and which is
+// active is theme DATA — read from the Theme facade, not here
+// (services never import core).
+//
+//   state:    available, busy, error
+//   commands: switchTo(name)
+
+Item {
+    id: rice
+
+    readonly property bool mock: false
+    readonly property bool available: true
+    property bool busy: false
+    property string error: ""
+
+    function switchTo(name) {
+        if (busy || !name || name.length === 0)
+            return;
+        busy = true;
+        error = "";
+        _proc.command = ["rice-switch", name];
+        _proc.running = true;
+    }
+
+    Process {
+        id: _proc
+        onExited: (code, status) => {
+            rice.busy = false;
+            if (code !== 0)
+                rice.error = "rice-switch failed (exit " + code + ")";
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/services/rice/qmldir
+++ b/modules/rice/runtime/quickshell/services/rice/qmldir
@@ -1,0 +1,1 @@
+singleton RiceState 1.0 RiceState.qml

--- a/modules/rice/runtime/quickshell/shell.qml
+++ b/modules/rice/runtime/quickshell/shell.qml
@@ -4,6 +4,7 @@ import "./modules/launcher"
 import "./modules/dashboard"
 import "./modules/osd"
 import "./modules/notifications"
+import "./modules/switcher"
 import "./modules/debug"
 
 // ── shell ─────────────────────────────────────────────────────
@@ -48,6 +49,11 @@ ShellRoot {
     Variants {
         model: Quickshell.screens
         Toasts {}
+    }
+
+    Variants {
+        model: Quickshell.screens
+        ThemeSwitcher {}
     }
 
     Variants {

--- a/modules/services/hyprland.nix
+++ b/modules/services/hyprland.nix
@@ -265,6 +265,7 @@
                 ] ++ (if config.rice.enable then [
                   # Rice shell surfaces (see docs/architecture/ROADMAP.md)
                   "${mainMod}, Space, exec, quickshell -c rice ipc call shell toggleLauncher"
+                  "${mainMod}, T, exec, quickshell -c rice ipc call shell toggleSwitcher"
                   "${mainMod}, N, exec, quickshell -c rice ipc call notifications toggleCenter"
                   "${mainMod} ${SECONDARY} ${TERTIARY}, N, exec, quickshell -c rice ipc call notifications clearAll"
                 ] else [


### PR DESCRIPTION
This pull request implements and documents the new two-layer theme switching machinery (D-018), which brings a robust, index-driven theme switcher to the project. The changes introduce a Nix-built `themes.json` index containing all available themes, their metadata, previews, and wallpapers, along with a dedicated `rice-switch` tool to atomically update the active theme pointer. The runtime now watches the pointer and index for live theme re-binding, and the switcher UI is updated to leverage this new infrastructure. Documentation and contracts are updated to reflect these architectural changes.

**Theme Switching Infrastructure (D-018):**
- Added `modules/rice/nix/_index-lib.nix`, which builds a `themes.json` index of all themes, including manifest paths, previews (authored or derived), and wallpaper lists. This enables zero-eval theme switching at runtime.
- Updated `modules/rice/nix/manifest.nix` to install both the default theme's manifest and the new `themes.json` index.
- Introduced `modules/rice/nix/switch.nix`, providing the `rice-switch` tool that updates the `$XDG_STATE_HOME/rice/active` pointer, orchestrates wallpaper changes, and notifies the running shell for live theme re-binding.

**Runtime Integration:**
- Enhanced `ManifestLoader.qml` to read and watch the `themes.json` index and the active pointer, resolving the active theme dynamically and supporting live re-theming. Added IPC handlers for scripting and testing. [[1]](diffhunk://#diff-cd91bec9f8ca1f83079f0ca0238eb297c96db9cef6717641544116acc3253d4aL7-R17) [[2]](diffhunk://#diff-cd91bec9f8ca1f83079f0ca0238eb297c96db9cef6717641544116acc3253d4aR96-R130) [[3]](diffhunk://#diff-cd91bec9f8ca1f83079f0ca0238eb297c96db9cef6717641544116acc3253d4aR163-R200)
- Updated `Theme.qml` to expose the full theme catalog from the index and the active theme name, enabling the switcher UI to display all available themes with previews.

**UI/UX Improvements:**
- Modified `ShellState.qml` to support a mutually exclusive switcher surface alongside launcher and dashboard, with new toggle/close functions for the theme switcher UI. [[1]](diffhunk://#diff-ce6e815e15fedc2c95b6f163742d06d5a9885c0fc11bff2ca023ff0a30026106R18) [[2]](diffhunk://#diff-ce6e815e15fedc2c95b6f163742d06d5a9885c0fc11bff2ca023ff0a30026106R36) [[3]](diffhunk://#diff-ce6e815e15fedc2c95b6f163742d06d5a9885c0fc11bff2ca023ff0a30026106R49-R60) [[4]](diffhunk://#diff-ce6e815e15fedc2c95b6f163742d06d5a9885c0fc11bff2ca023ff0a30026106R83-R85)

**Documentation and Contracts:**
- Added and updated architecture decision records (DECISIONS.md) and roadmap (ROADMAP.md) to document the concretization of the theme switch machinery (D-018), the index, pointer, and preview derivation, and the future direction for wallpapers and preferences. [[1]](diffhunk://#diff-e22831aebcbc6fc53b016a8b1a3299316f39d1c2d2244233d3c6155d1e378ac1R188-R212) [[2]](diffhunk://#diff-5de6d1bbf64c2d347cb388efbf23d21ea8dd0e9266a8f06d72637baa801f1834L214-R274)
- Updated theme manifest contract and authoring documentation to clarify that previews are no longer a manifest field but are provided via authored or derived preview images, as per D-018. [[1]](diffhunk://#diff-b8e5f4c4e6446876d95dcb6beb890a3a04549625b1d13ca80137bc493292026aL22-R23) [[2]](diffhunk://#diff-c4a688ffd9923c6e26419c471a8016db7da9cefaafbf3a6139de8802f6110fd8L25-R26) [[3]](diffhunk://#diff-10b457f2fdd4efd9306153a005f1ccda9dcfad4033cc1b16fc6b8c5f51321833L85-R89)

These changes lay the foundation for a robust, index-driven theme switching system, enabling efficient, user-friendly theme management and future extensibility.