### PR TITLE
fix(wallpaper): boot restore recovers stale store paths via rice state

### DIFF
--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -5,28 +5,67 @@ _: {
       inherit (osConfig.environment.desktop.theme) wallpaper;
       awww = "${pkgs.awww}/bin/awww";
 
-      # Boot-time wallpaper restore script: reads persisted path, falls back to Nix default
+      # Boot-time wallpaper restore: persisted path, with rice-aware
+      # recovery when it went stale (store paths in the persist file
+      # die on rebuild+GC — the assets hash changes whenever any theme
+      # asset does; nh clean collects the old one). Recovery mirrors
+      # rice-switch (D-019): basename re-match against the ACTIVE
+      # theme's current wallpaper list, else the theme's remembered
+      # prefs entry, else its first wallpaper, else the Nix default.
       wallpaper-restore = pkgs.writeShellScriptBin "wallpaper-restore" ''
         set -euo pipefail
+        JQ=${pkgs.jq}/bin/jq
         PERSIST_FILE="$HOME/.config/wallpaper/current"
         DEFAULT="${wallpaper}"
 
-        # Start daemon if not running
+        # Start daemon if not running, then wait until it answers
+        # (a fixed grace period races a cold multi-monitor boot).
         ${awww}-daemon 2>/dev/null &
         disown
-        # Give daemon a moment to initialise
-        sleep 0.3
+        for _ in $(seq 1 50); do
+          ${awww} query >/dev/null 2>&1 && break
+          sleep 0.1
+        done
 
-        # Use persisted wallpaper if it exists and points to a real file
-        WP="$DEFAULT"
+        SAVED=""
         if [ -f "$PERSIST_FILE" ]; then
           SAVED=$(cat "$PERSIST_FILE")
-          if [ -f "$SAVED" ]; then
-            WP="$SAVED"
-          fi
         fi
 
-        # Seed the persist file if missing
+        WP=""
+        if [ -n "$SAVED" ] && [ -f "$SAVED" ]; then
+          WP="$SAVED"
+        else
+          # Persisted path is gone — recover through the rice state
+          # (skipped gracefully on non-rice hosts: no index, no jq run).
+          INDEX="$HOME/.config/rice/themes.json"
+          POINTER="''${XDG_STATE_HOME:-$HOME/.local/state}/rice/active"
+          PREFS="''${XDG_STATE_HOME:-$HOME/.local/state}/rice/prefs.json"
+          if [ -r "$INDEX" ]; then
+            NAME=""
+            [ -r "$POINTER" ] && NAME=$(cat "$POINTER")
+            if [ -z "$NAME" ] || ! $JQ -e --arg n "$NAME" '.themes[$n]' "$INDEX" >/dev/null 2>&1; then
+              NAME=$($JQ -r '.default // empty' "$INDEX")
+            fi
+            if [ -n "$NAME" ]; then
+              if [ -n "$SAVED" ]; then
+                WP=$($JQ -r --arg n "$NAME" --arg b "$(basename "$SAVED")" \
+                  '.themes[$n].wallpapers[] | select(endswith("/" + $b))' "$INDEX" | head -n1)
+              fi
+              if { [ -z "$WP" ] || [ ! -f "$WP" ]; } && [ -r "$PREFS" ]; then
+                WP=$($JQ -r --arg n "$NAME" '.wallpapers[$n] // empty' "$PREFS")
+              fi
+              if [ -z "$WP" ] || [ ! -f "$WP" ]; then
+                WP=$($JQ -r --arg n "$NAME" '.themes[$n].wallpapers[0] // empty' "$INDEX")
+              fi
+            fi
+          fi
+        fi
+        if [ -z "$WP" ] || [ ! -f "$WP" ]; then
+          WP="$DEFAULT"
+        fi
+
+        # Re-seed the persist file with the resolved (live) path
         mkdir -p "$(dirname "$PERSIST_FILE")"
         echo "$WP" > "$PERSIST_FILE"
 


### PR DESCRIPTION
The persist file stores absolute /nix/store paths; the theme assets hash changes on any asset rebuild and nh clean collects the old one, so after rebuild+GC wallpaper-restore silently fell back to the Nix default — 'wallpaper doesn't persist on reboot'. Restore now recovers a dead path the same way rice-switch does (D-019): basename re-match against the active theme's current wallpaper list, else the theme's prefs.json entry, else wallpapers[0], else the Nix default. Non-rice hosts unchanged (no index → straight to default). Also replaces the 0.3s daemon grace sleep with a readiness poll (awww query, 5s cap).

Sandbox-verified: dead-path re-match, prefs fallback, and non-rice default all resolve correctly and re-seed the persist file.