### PR TITLE
feat: phase 13 — motion v2 + ambient foundation (D-021/D-022)

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -81,7 +81,8 @@ theme plugins → {core, components, utils} + injected services only
 1. **System state** — owned by services; widgets read, commands go through service
    methods ([service-contract](contracts/service-contract.md)).
 2. **Shell UI state** — `core/ShellState.qml`: active popout, launcher visibility,
-   OSD queue, debug overlay.
+   OSD queue, debug overlay, plus governor-pushed flags (`reduceMotion`,
+   `ambientActive` — written only by `modules/ambient/AmbientController`, D-021).
 3. **User prefs** — `$XDG_STATE_HOME/rice/`. The active-theme pointer is written
    only by `rice-switch` and read/watched by `core/ManifestLoader` as manifest-
    resolution input (D-018); `prefs.json` is written only by the `PrefsState`

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -264,6 +264,51 @@ Status values: `active` | `superseded by D-NNN`.
   no-ops (the lockscreen never followed the live wallpaper). Patterns are now
   whitespace-tolerant EREs anchored on the key.
 
+### D-021 — Ambient effects engine (tokens.effects + governor)
+
+- Date: 2026-07-07 · Status: active
+- The motion contract's ambient tier (T1) is realized as: an optional
+  closed-core `tokens.effects = { layers = [ { type; tint; opacity; … } ]; }`
+  block (validated at build; layer types v1: `fog`, `particles`, `vignette`;
+  tints are color TOKEN REFS like `"accent.primary"`, never literals — L-005).
+  Theme-neutral primitives live in `components/effects/`; `core/Effects.qml`
+  is the sole reader of the config and enforces budgets STRUCTURALLY
+  (≤ 4 layers, ≤ 12 particles, opacity caps) — what it does not emit cannot
+  render. Rendering happens in a per-monitor `modules/ambient/AmbientLayer`
+  (layer-shell Bottom, input-transparent, unmapped + unloaded when off, so
+  ambient-off steady state costs exactly zero).
+- The run/pause policy lives in ONE place: `modules/ambient/AmbientController`
+  composes PrefsState (reduce-motion, ambient mode `auto|off`) + PowerState
+  (on battery ⇒ pause) + HyprState (any fullscreen toplevel ⇒ pause) and
+  pushes verdicts onto `ShellState.ambientActive` / `ShellState.reduceMotion`.
+  This bridge exists because core/components may not import services; effect
+  primitives bind ShellState only.
+- prefs.json (D-019 file, same sole-writer rule) gains an additive `motion`
+  block: `{ reduce: bool, ambient: "auto"|"off" }`.
+- Why: atmosphere is the point of a rice, but D-006 forbids theming the
+  runtime and rule-of-import forbids effects reading system state; data-driven
+  neutral primitives + a single modules-layer governor give themes expressive
+  ambience while keeping the runtime boring, budgeted, and pausable.
+
+### D-022 — Motion v2: manifest easings honored, ceremonial, reduce-motion
+
+- Date: 2026-07-07 · Status: active
+- The manifest's named easing curves (`tokens.motion.easings`, declared in the
+  contract since v1 but silently ignored — Theme hardcoded enums) are now
+  resolved by `Theme` from curve-name strings, warn-and-default (OutCubic) on
+  unknown names. Optional `tokens.motion.durations.ceremonial` is added for
+  infrequent, deliberate moments (power menu, theme switch); it defaults to
+  `slow` so undeclaring themes keep one tempo. Both changes are additive —
+  schemaVersion stays 2.
+- The motion contract's global reduce-motion flag is concretized:
+  `PrefsState.reduceMotion` → pushed onto `ShellState.reduceMotion` by the
+  D-021 governor → folded into `Motion.enabled`, so every animation collapses
+  to instant through the existing spec mechanism.
+- Vocabulary: `awaken` joins (one-shot startup reveal of surface contents).
+  The motion vocabulary continues to grow only when a surface needs a name
+  (D-014 anti-speculation) — the LoTM plan's remaining names land with their
+  consuming phases, not ahead of them.
+
 ---
 
 ## Legacy imports

--- a/docs/architecture/ROADMAP.md
+++ b/docs/architecture/ROADMAP.md
@@ -299,12 +299,54 @@ Concretized as D-020: the lockscreen joins the rice at lock time.
   leaves the background's empty `monitor=` alone. Real-lock check after
   rebuild: `rice-switch cyberpunk` + lock → cyan/Orbitron without rebuild.
 
+## Phase 13 — Motion v2 + ambient foundation ✅
+
+Concretized as D-021 (ambient effects engine) and D-022 (motion v2). First
+phase of the LoTM immersion plan: capability systems before content — the
+runtime gains atmosphere machinery; LOTM opts in as pure data.
+
+- ✅ Manifest easings honored: `Theme` resolves named curve strings
+  (warn-and-default OutCubic); they had been contract-declared but ignored.
+  Optional `durations.ceremonial` (defaults to slow). Validation for both in
+  `mkThemeManifest` — plus `tokens.effects` shape/type checks and the L-005
+  token-ref-only tint rule (negative-tested: literal color and unknown layer
+  type both fail the build with precise messages).
+- ✅ Ambient engine: `core/Effects` (sole effects-config reader; structural
+  budgets ≤4 layers/≤12 particles/opacity caps), theme-neutral T1 primitives
+  `components/effects/{FogLayer,ParticleField,VignetteLayer}` (Canvas painted
+  once, transform/opacity animation only), per-monitor
+  `modules/ambient/AmbientLayer` (layer-shell Bottom, empty input mask,
+  unmapped + Loader-unloaded when paused).
+- ✅ Governor: `modules/ambient/AmbientController` — the one place run/pause
+  policy lives — pushes `ShellState.{ambientActive,reduceMotion}` from
+  PrefsState (new `motion` prefs block: reduce, ambient auto|off) +
+  PowerState (battery ⇒ pause) + HyprState (new `anyFullscreen` via Wayland
+  foreign-toplevel watchers, event-driven). IPC `ambient status|setMode|
+  setReduceMotion` for scripting/tests. `Motion.enabled` folds in
+  reduce-motion; new `awaken` spec drives the bar's one-shot startup reveal.
+- ✅ LOTM manifest: easings + ceremonial=700 + ambient=true + three layers
+  (fog in fog-blue, gold ember motes, sunken vignette). Cyberpunk untouched —
+  manifest evals byte-equivalent (no effects key; loader defaults fill in).
+- Verified: rice-lint clean; both manifests build; sandboxed live run — zero
+  QML warnings, `ambient status` truthful, reduce-motion and mode=off each
+  pause and restore live, three `rice-ambient` windows on the bottom layer
+  unmap to 0 on pause and remap on resume (hyprctl layers). Budget: ambient
+  OFF = 0.0% CPU over 10s (contract steady-state holds); ambient ON = 8.1%
+  of one core across 3 monitors (T1 continuous drift; acceptable for the
+  opt-in tier — the Phase 20 shader path is the planned cheaper fog).
+- Caveats: the fullscreen gate's live flip was not exercised (watchers attach
+  and count correctly over real toplevels; flip is a property binding) — first
+  fullscreen video will confirm. Fog drifts in from offscreen over ~1 min by
+  design (roll-in beats pop-in; also hides governor restarts). Bug found by
+  the smoke test: unqualified `requestPaint()` inside `Connections` is a
+  ReferenceError — qualify with the Canvas id.
+
 ## Later surfaces (slot in after Phase 6, order by appetite)
 
 Volume/brightness OSDs · media controls (MprisState) · power menu · clipboard
 history · dashboard widgets (system monitor, weather, dev widgets) · optional
-dock · LOTM plugin widgets (tarot/ritual — proves the plugin contract) ·
-ambient effects tier (Phase 4+ of `contracts/motion-contract.md`).
+dock · LOTM plugin widgets (tarot/ritual — proves the plugin contract).
+The ambient effects tier landed as Phase 13 (D-021).
 
 ## Deferred / future
 

--- a/docs/architecture/contracts/motion-contract.md
+++ b/docs/architecture/contracts/motion-contract.md
@@ -7,11 +7,18 @@ Motion exists to reinforce state changes and atmosphere — never for its own sa
 
 ```text
 tokens.motion.durations  { fast, base, slow, overlay }      # ms
+tokens.motion.durations.ceremonial   # OPTIONAL (D-022): rare, deliberate
+                                     # moments; defaults to slow
 tokens.motion.easings    { standard, enter, exit, emphasis } # named curve specs
+                                     # (Qt easing names, resolved by Theme;
+                                     # unknown → warn + OutCubic, D-022)
 tokens.motion.intensity  "calm" | "lively"                   # global scaler hint
 tokens.motion.ambient    bool                                 # opt-in ambient tier
 tokens.motion.enabled    bool                                 # theme-level kill switch
 tokens.sound             { event → file }                     # optional event map
+tokens.effects.layers    [ { type, tint, … } ]                # OPTIONAL (D-021):
+                                     # ambient atmosphere config, see
+                                     # theme-manifest.md; budgets below apply
 ```
 
 ## The Motion singleton
@@ -42,9 +49,15 @@ Rules:
 | **T2** | shader effects | Per-theme opt-in. Must ship a T0 degradation path; failure to compile falls back silently. |
 
 **Ambient tier:** themes may declare idle atmosphere effects (T1/T2) via
-`tokens.motion.ambient = true`. Ambient effects run only when ambient is on AND
-reduce-motion is off, pause on fullscreen, and count against the budgets below.
-This is the single governed exception to rule 2 (L-007 generalized by D-010).
+`tokens.motion.ambient = true` plus `tokens.effects.layers` (D-021). Ambient
+effects run only when ambient is on AND reduce-motion is off, pause on
+fullscreen and on battery, and count against the budgets below. This is the
+single governed exception to rule 2 (L-007 generalized by D-010).
+Mechanism (D-021): `core/Effects` resolves and clamps the config;
+`modules/ambient/AmbientController` is the one place the run/pause policy
+lives, pushing `ShellState.ambientActive`; per-monitor
+`modules/ambient/AmbientLayer` windows mount `components/effects/` primitives
+and unload entirely while paused (ambient-off steady state costs zero).
 
 ## Budgets
 

--- a/docs/architecture/contracts/theme-manifest.md
+++ b/docs/architecture/contracts/theme-manifest.md
@@ -43,12 +43,24 @@ exclusively through the `Theme` facade.
     };
     motion = {                    # see contracts/motion-contract.md
       durations = { fast; base; slow; overlay; };
+      # OPTIONAL (D-022): infrequent, deliberate moments; defaults to slow.
+      # durations.ceremonial = 700;
       easings   = { standard; enter; exit; emphasis; };   # named curve specs
+      # Curve names are Qt easing names ("OutCubic", "InOutBack", …),
+      # resolved by the runtime; unknown names warn and fall back (D-022).
       intensity = "calm" | "lively";                       # global scaler hint
       ambient   = false;          # opt-in to the ambient effect tier
       enabled   = true;           # theme-level motion kill switch
     };
     sound = { };                  # OPTIONAL: event name → file path (see motion-contract)
+    effects = {                   # OPTIONAL (D-021): ambient atmosphere layers,
+      layers = [                  # rendered only while motion.ambient opts in
+        # type ∈ "fog" | "particles" | "vignette" (v1 set);
+        # tint is a color TOKEN REF ("accent.primary"), never a literal (L-005);
+        # opacity/speed/count are clamped to the motion-contract budgets.
+        # { type = "fog"; tint = "accent.secondary"; opacity = 0.1; speed = 1.0; band = "bottom"; }
+      ];
+    };
   };
 
   palette = { };                  # OPEN, optional: extra named colors, namespaced by the

--- a/modules/rice/nix/_manifest-lib.nix
+++ b/modules/rice/nix/_manifest-lib.nix
@@ -48,6 +48,41 @@ let
     (theme.meta.schemaVersion or (fail "missing meta.schemaVersion"))
   ];
 
+  # Motion v2 (D-022) + ambient effects (D-021): optional keys,
+  # typechecked when present so a theme typo fails the build, never
+  # the running shell. Easing names resolve (warn-and-default) in
+  # the runtime; only the shape is enforced here.
+  motionExtraChecks =
+    lib.mapAttrsToList
+      (k: v:
+        if builtins.isString v then true
+        else fail "tokens.motion.easings.${k} must be a curve-name string")
+      (theme.tokens.motion.easings or { })
+    ++ [
+      (let c = theme.tokens.motion.durations.ceremonial or null; in
+      if c == null || builtins.isInt c then true
+      else fail "tokens.motion.durations.ceremonial must be an int (ms)")
+    ];
+
+  effectTypes = [ "fog" "particles" "vignette" ];
+  # Tints are color TOKEN REFS (L-005: effects derive from tokens,
+  # never literal colors): "<bg|fg|accent|state>.<key>".
+  isTokenRef = v:
+    builtins.isString v
+    && builtins.match "(bg|fg|accent|state)\\.[a-zA-Z0-9]+" v != null;
+  effectChecks =
+    let layers = (theme.tokens.effects or { }).layers or [ ]; in
+    if !builtins.isList layers
+    then fail "tokens.effects.layers must be a list"
+    else map
+      (l:
+        if !(lib.elem (l.type or null) effectTypes)
+        then fail "tokens.effects layer type must be one of [${lib.concatStringsSep " " effectTypes}], got ${builtins.toJSON (l.type or null)}"
+        else if l ? tint && !isTokenRef l.tint
+        then fail "tokens.effects tint must be a color token ref like \"accent.primary\" (L-005), got ${builtins.toJSON l.tint}"
+        else true)
+      layers;
+
   iconChecks = lib.mapAttrsToList
     (name: value:
       if lib.hasInfix "/" value && !builtins.pathExists (themeDir + "/assets/${value}")
@@ -105,7 +140,8 @@ let
     };
   };
 
-  checks = tokenChecks ++ metaChecks ++ iconChecks ++ rasterChecks;
+  checks = tokenChecks ++ metaChecks ++ iconChecks ++ rasterChecks
+    ++ motionExtraChecks ++ effectChecks;
 in
 {
   inherit manifest;

--- a/modules/rice/runtime/quickshell/components/effects/FogLayer.qml
+++ b/modules/rice/runtime/quickshell/components/effects/FogLayer.qml
@@ -1,0 +1,88 @@
+import QtQuick
+
+// ── FogLayer ──────────────────────────────────────────────────
+// T1 ambient primitive (contracts/motion-contract.md): soft
+// gradient blobs drifting slowly across a band of the surface.
+// Each blob is a Canvas painted ONCE to a texture; steady-state
+// cost is transform + opacity animation only — no repaints.
+//
+// Theme-neutral and presentation-only: tint/strength/speed arrive
+// resolved from core/Effects via the mounting surface, which also
+// owns the `running` gate (ShellState.ambientActive). Blobs start
+// fully offscreen and drift in, so a (re)start never pops.
+
+Item {
+    id: fog
+
+    property color tint: "transparent"
+    property real strength: 0.1   // peak blob opacity
+    property real speed: 1.0      // 1.0 = base drift tempo
+    property string band: "bottom" // bottom | top | full
+    property bool running: true
+
+    clip: true
+
+    readonly property real _bandH: band === "full" ? height : height * 0.45
+
+    Repeater {
+        model: 3
+
+        Canvas {
+            id: blob
+
+            required property int index
+
+            width: Math.max(1, fog.width * (0.45 + 0.22 * index))
+            height: Math.max(1, fog._bandH)
+            y: fog.band === "top" ? 0 : fog.height - fog._bandH
+            opacity: 0
+
+            onPaint: {
+                const ctx = getContext("2d");
+                ctx.reset();
+                const g = ctx.createRadialGradient(
+                    width / 2, height * 0.62, 0,
+                    width / 2, height * 0.62, width / 2);
+                g.addColorStop(0, Qt.rgba(fog.tint.r, fog.tint.g, fog.tint.b, 1));
+                g.addColorStop(1, Qt.rgba(fog.tint.r, fog.tint.g, fog.tint.b, 0));
+                ctx.fillStyle = g;
+                ctx.fillRect(0, 0, width, height);
+            }
+            onWidthChanged: requestPaint()
+            onHeightChanged: requestPaint()
+
+            Connections {
+                target: fog
+                function onTintChanged() {
+                    blob.requestPaint();
+                }
+            }
+
+            // Drift: fully offscreen left → fully offscreen right,
+            // so the loop's wrap-around is never visible.
+            NumberAnimation on x {
+                running: fog.running && fog.visible
+                loops: Animation.Infinite
+                from: -blob.width
+                to: fog.width
+                duration: (90000 + blob.index * 34000) / fog.speed
+            }
+
+            // Breath: slow ±30% opacity oscillation around strength.
+            SequentialAnimation on opacity {
+                running: fog.running && fog.visible
+                loops: Animation.Infinite
+                NumberAnimation {
+                    to: fog.strength
+                    duration: (9000 + blob.index * 2600) / fog.speed
+                    easing.type: Easing.InOutSine
+                }
+                NumberAnimation {
+                    to: fog.strength * 0.7
+                    duration: (11000 + blob.index * 2100) / fog.speed
+                    easing.type: Easing.InOutSine
+                }
+            }
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/components/effects/ParticleField.qml
+++ b/modules/rice/runtime/quickshell/components/effects/ParticleField.qml
@@ -1,0 +1,80 @@
+import QtQuick
+
+// ── ParticleField ─────────────────────────────────────────────
+// T1 ambient primitive: a sparse set of motes rising slowly.
+// Count is capped upstream by core/Effects (structural budget);
+// per-mote variety is deterministic (golden-ratio spread), so the
+// field looks organic without Math.random re-rolls on reload.
+//
+// Presentation-only; `running` is owned by the mounting surface.
+
+Item {
+    id: field
+
+    property color tint: "transparent"
+    property real strength: 0.3   // peak mote opacity
+    property real speed: 1.0
+    property int count: 8
+    property bool running: true
+
+    clip: true
+
+    Repeater {
+        model: field.count
+
+        Rectangle {
+            id: mote
+
+            required property int index
+
+            // Deterministic per-mote variety in [0,1).
+            readonly property real u: (index * 0.618034 + 0.213) % 1
+            readonly property int riseMs: Math.round((16000 + u * 12000) / field.speed)
+
+            width: 2 + Math.round(u * 2)
+            height: width
+            radius: width / 2
+            color: field.tint
+            opacity: 0
+            x: field.width * ((u * 7.13) % 1)
+            y: field.height + height
+
+            SequentialAnimation {
+                running: field.running && field.visible
+                loops: Animation.Infinite
+
+                // Stagger so motes don't rise as one synchronized wave.
+                PauseAnimation {
+                    duration: Math.round(mote.u * 9000)
+                }
+                ParallelAnimation {
+                    NumberAnimation {
+                        target: mote
+                        property: "y"
+                        from: field.height + mote.height
+                        to: field.height * 0.2
+                        duration: mote.riseMs
+                    }
+                    SequentialAnimation {
+                        NumberAnimation {
+                            target: mote
+                            property: "opacity"
+                            from: 0
+                            to: field.strength
+                            duration: Math.round(mote.riseMs * 0.25)
+                        }
+                        PauseAnimation {
+                            duration: Math.round(mote.riseMs * 0.4)
+                        }
+                        NumberAnimation {
+                            target: mote
+                            property: "opacity"
+                            to: 0
+                            duration: Math.round(mote.riseMs * 0.35)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/components/effects/VignetteLayer.qml
+++ b/modules/rice/runtime/quickshell/components/effects/VignetteLayer.qml
@@ -1,0 +1,45 @@
+import QtQuick
+
+// ── VignetteLayer ─────────────────────────────────────────────
+// Static edge-darkening wash: a radial gradient painted once
+// (repainted only on resize/tint change). Costs nothing at steady
+// state — it is a texture, not an animation — but lives with the
+// ambient primitives so one governor gates all atmosphere.
+
+Item {
+    id: vignette
+
+    property color tint: "transparent"
+    property real strength: 0.2
+
+    Canvas {
+        id: wash
+
+        anchors.fill: parent
+
+        onPaint: {
+            const ctx = getContext("2d");
+            ctx.reset();
+            const cx = width / 2;
+            const cy = height / 2;
+            const r = Math.sqrt(cx * cx + cy * cy);
+            const g = ctx.createRadialGradient(cx, cy, r * 0.55, cx, cy, r);
+            g.addColorStop(0, Qt.rgba(vignette.tint.r, vignette.tint.g, vignette.tint.b, 0));
+            g.addColorStop(1, Qt.rgba(vignette.tint.r, vignette.tint.g, vignette.tint.b, vignette.strength));
+            ctx.fillStyle = g;
+            ctx.fillRect(0, 0, width, height);
+        }
+        onWidthChanged: requestPaint()
+        onHeightChanged: requestPaint()
+
+        Connections {
+            target: vignette
+            function onTintChanged() {
+                wash.requestPaint();
+            }
+            function onStrengthChanged() {
+                wash.requestPaint();
+            }
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/components/effects/qmldir
+++ b/modules/rice/runtime/quickshell/components/effects/qmldir
@@ -1,0 +1,3 @@
+FogLayer 1.0 FogLayer.qml
+ParticleField 1.0 ParticleField.qml
+VignetteLayer 1.0 VignetteLayer.qml

--- a/modules/rice/runtime/quickshell/core/Effects.qml
+++ b/modules/rice/runtime/quickshell/core/Effects.qml
@@ -1,0 +1,79 @@
+pragma Singleton
+import QtQuick
+
+// ── Effects ───────────────────────────────────────────────────
+// The single reader of ambient-effect config (Theme.effects,
+// D-021) and the place effect budgets are enforced STRUCTURALLY:
+// a layer this facade does not emit cannot render. Consumers
+// (components/effects primitives via modules/ambient) read the
+// resolved `layers` list only; whether effects RUN is not decided
+// here — that policy lives in modules/ambient/AmbientController,
+// which pushes its verdict onto ShellState.ambientActive.
+//
+// Layer types v1: fog · particles · vignette. Tints arrive as
+// color token refs ("accent.primary") and resolve here (L-005:
+// effect colors derive from tokens, never literals).
+
+QtObject {
+    id: effects
+
+    // Hard budgets (contracts/motion-contract.md). Values beyond
+    // these are clamped, not rejected — the theme built, so it
+    // renders; it just renders within budget.
+    readonly property int maxLayers: 4
+    readonly property int maxParticles: 12
+
+    readonly property var layers: {
+        const raw = (Theme.effects ?? {}).layers ?? [];
+        const out = [];
+        for (const l of raw.slice(0, maxLayers)) {
+            if (l.type === "fog")
+                out.push({
+                    type: "fog",
+                    tint: _colorRef(l.tint ?? "fg.subtle"),
+                    strength: _clamp(l.opacity ?? 0.10, 0, 0.35),
+                    speed: _clamp(l.speed ?? 1.0, 0.1, 3.0),
+                    band: l.band ?? "bottom",
+                    count: 0
+                });
+            else if (l.type === "particles")
+                out.push({
+                    type: "particles",
+                    tint: _colorRef(l.tint ?? "accent.primary"),
+                    strength: _clamp(l.opacity ?? 0.30, 0, 0.6),
+                    speed: _clamp(l.speed ?? 1.0, 0.1, 3.0),
+                    band: "full",
+                    count: Math.min(Math.max(1, l.count ?? 8), maxParticles)
+                });
+            else if (l.type === "vignette")
+                out.push({
+                    type: "vignette",
+                    tint: _colorRef(l.tint ?? "bg.sunken"),
+                    strength: _clamp(l.opacity ?? 0.20, 0, 0.5),
+                    speed: 0,
+                    band: "full",
+                    count: 0
+                });
+            else
+                console.warn("Effects: unknown layer type '" + l.type + "' — skipped");
+        }
+        return out;
+    }
+
+    function _clamp(v, lo, hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+
+    // "group.key" → Theme.colors.group.key; unknown refs degrade
+    // visibly-sane (fg.subtle) with a warning, never an error.
+    function _colorRef(ref) {
+        const parts = (typeof ref === "string" ? ref : "").split(".");
+        const group = Theme.colors[parts[0]];
+        const c = group ? group[parts[1]] : undefined;
+        if (c === undefined) {
+            console.warn("Effects: unknown color token ref '" + ref + "' — using fg.subtle");
+            return Theme.colors.fg.subtle;
+        }
+        return c;
+    }
+}

--- a/modules/rice/runtime/quickshell/core/ManifestLoader.qml
+++ b/modules/rice/runtime/quickshell/core/ManifestLoader.qml
@@ -44,8 +44,12 @@ Item {
             },
             motion: {
                 durations: { fast: 150, base: 250, slow: 350, overlay: 110 },
+                easings: { standard: "OutCubic", enter: "OutQuint", exit: "InCubic", emphasis: "OutBack" },
+                ambient: false,
                 enabled: true
-            }
+            },
+            // Ambient-effect config (D-021); read only by core/Effects.
+            effects: { layers: [] }
         },
         assets: {
             root: "",

--- a/modules/rice/runtime/quickshell/core/Motion.qml
+++ b/modules/rice/runtime/quickshell/core/Motion.qml
@@ -7,15 +7,20 @@ import QtQuick
 // Specs resolve from Theme motion tokens and collapse to 0ms when
 // motion is disabled, so every animation is correct without motion.
 //
-// v1 vocabulary (grown only when a surface needs a new name):
+// v2 vocabulary (grown only when a surface needs a new name):
 //   panelOpen   — a surface/panel entering
 //   panelClose  — a surface/panel leaving (faster, sharper)
 //   stateChange — small state reactions (hover, value changes)
+//   awaken      — one-shot startup reveal of surface contents
+//
+// enabled folds in the global reduce-motion pref (D-022): the pref
+// lives in PrefsState and is pushed onto ShellState by the modules
+// layer, because core may not import services.
 
 QtObject {
     id: motion
 
-    readonly property bool enabled: Theme.motion.enabled
+    readonly property bool enabled: Theme.motion.enabled && !ShellState.reduceMotion
 
     readonly property QtObject panelOpen: QtObject {
         readonly property int duration: motion.enabled ? Theme.motion.durations.base : 0
@@ -30,5 +35,10 @@ QtObject {
     readonly property QtObject stateChange: QtObject {
         readonly property int duration: motion.enabled ? Theme.motion.durations.fast : 0
         readonly property int easing: Theme.motion.easings.standard
+    }
+
+    readonly property QtObject awaken: QtObject {
+        readonly property int duration: motion.enabled ? Theme.motion.durations.slow : 0
+        readonly property int easing: Theme.motion.easings.enter
     }
 }

--- a/modules/rice/runtime/quickshell/core/ShellState.qml
+++ b/modules/rice/runtime/quickshell/core/ShellState.qml
@@ -21,6 +21,23 @@ Item {
     property bool osdVisible: false
     property bool debugVisible: false
 
+    // ── Ambient & motion flags (D-021/D-022) ──────────────────
+    // Pushed by modules/ambient/AmbientController: the policy needs
+    // services (prefs, power, compositor), which nothing below the
+    // modules layer may import. Core and components only READ these.
+    property bool reduceMotion: false
+    property bool ambientActive: false
+
+    // One-shot startup reveal: flips shortly after load so surface
+    // contents fade in (Motion.awaken) instead of popping. UI binds
+    // to the flag; with motion disabled the reveal is instant.
+    property bool awakened: false
+    Timer {
+        interval: 120
+        running: !shell.awakened
+        onTriggered: shell.awakened = true
+    }
+
     // Single-open popout (L-002): the widgetId whose popout is up.
     property string activePopout: ""
 

--- a/modules/rice/runtime/quickshell/core/Theme.qml
+++ b/modules/rice/runtime/quickshell/core/Theme.qml
@@ -85,14 +85,47 @@ QtObject {
             readonly property int base: theme._t.motion.durations.base
             readonly property int slow: theme._t.motion.durations.slow
             readonly property int overlay: theme._t.motion.durations.overlay
+            // Optional (D-022): reserved for infrequent, deliberate
+            // moments. Falls back to slow so themes that never
+            // declare it keep one coherent tempo.
+            readonly property int ceremonial: theme._t.motion.durations.ceremonial ?? theme._t.motion.durations.slow
         }
+        // Named curve specs from the manifest (D-022) — previously
+        // declared in the contract but ignored by the runtime.
         readonly property QtObject easings: QtObject {
-            readonly property int standard: Easing.OutCubic
-            readonly property int enter: Easing.OutQuint
-            readonly property int exit: Easing.InCubic
-            readonly property int emphasis: Easing.OutBack
+            readonly property int standard: theme._easing(theme._t.motion.easings.standard)
+            readonly property int enter: theme._easing(theme._t.motion.easings.enter)
+            readonly property int exit: theme._easing(theme._t.motion.easings.exit)
+            readonly property int emphasis: theme._easing(theme._t.motion.easings.emphasis)
         }
+        readonly property bool ambient: theme._t.motion.ambient ?? false
         readonly property bool enabled: theme._t.motion.enabled
+    }
+
+    // Raw ambient-effect config (D-021). Read ONLY by core/Effects,
+    // which resolves tint token refs and enforces the budgets.
+    readonly property var effects: theme._t.effects ?? ({ layers: [] })
+
+    // Curve-name string → Easing enum. Unknown names degrade to
+    // OutCubic with a warning — a theme typo never breaks motion.
+    function _easing(name) {
+        const v = ({
+            "Linear": Easing.Linear,
+            "InQuad": Easing.InQuad, "OutQuad": Easing.OutQuad, "InOutQuad": Easing.InOutQuad,
+            "InCubic": Easing.InCubic, "OutCubic": Easing.OutCubic, "InOutCubic": Easing.InOutCubic,
+            "InQuart": Easing.InQuart, "OutQuart": Easing.OutQuart, "InOutQuart": Easing.InOutQuart,
+            "InQuint": Easing.InQuint, "OutQuint": Easing.OutQuint, "InOutQuint": Easing.InOutQuint,
+            "InExpo": Easing.InExpo, "OutExpo": Easing.OutExpo, "InOutExpo": Easing.InOutExpo,
+            "InSine": Easing.InSine, "OutSine": Easing.OutSine, "InOutSine": Easing.InOutSine,
+            "InBack": Easing.InBack, "OutBack": Easing.OutBack, "InOutBack": Easing.InOutBack,
+            "InElastic": Easing.InElastic, "OutElastic": Easing.OutElastic,
+            "InBounce": Easing.InBounce, "OutBounce": Easing.OutBounce
+        })[name];
+        if (v === undefined) {
+            console.warn("Theme: unknown easing curve '" + name + "' — using OutCubic");
+            return Easing.OutCubic;
+        }
+        return v;
     }
 
     // ── Icons ─────────────────────────────────────────────────

--- a/modules/rice/runtime/quickshell/core/qmldir
+++ b/modules/rice/runtime/quickshell/core/qmldir
@@ -2,4 +2,5 @@ singleton Theme 1.0 Theme.qml
 singleton ManifestLoader 1.0 ManifestLoader.qml
 singleton ShellState 1.0 ShellState.qml
 singleton Motion 1.0 Motion.qml
+singleton Effects 1.0 Effects.qml
 MotionAnim 1.0 MotionAnim.qml

--- a/modules/rice/runtime/quickshell/modules/ambient/AmbientController.qml
+++ b/modules/rice/runtime/quickshell/modules/ambient/AmbientController.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import Quickshell.Io
+import "../../core"
+import "../../services/prefs"
+import "../../services/power"
+import "../../services/hypr"
+
+// ── AmbientController ─────────────────────────────────────────
+// The ambient governor (D-021): the ONLY place the run/pause
+// policy for atmosphere effects lives. It composes user prefs
+// (reduce-motion, ambient mode) with system state (battery,
+// fullscreen) and pushes the verdict onto ShellState — because
+// core and components may not import services, this modules-layer
+// bridge is how the motion contract's T1 gating stays layer-legal.
+//
+// Instantiated once in shell.qml (not a singleton: it must run
+// even when no ambient surface exists, since it also forwards the
+// global reduce-motion pref that gates ALL motion).
+
+Item {
+    id: governor
+
+    readonly property bool ambientAllowed: Theme.motion.ambient
+        && Theme.motion.enabled
+        && Effects.layers.length > 0
+        && !PrefsState.reduceMotion
+        && PrefsState.ambientMode !== "off"
+        && !PowerState.onBattery
+        && !HyprState.anyFullscreen
+
+    Binding {
+        target: ShellState
+        property: "reduceMotion"
+        value: PrefsState.reduceMotion
+    }
+
+    Binding {
+        target: ShellState
+        property: "ambientActive"
+        value: governor.ambientAllowed
+    }
+
+    IpcHandler {
+        target: "ambient"
+
+        function status(): string {
+            return JSON.stringify({
+                active: ShellState.ambientActive,
+                mode: PrefsState.ambientMode,
+                reduceMotion: PrefsState.reduceMotion,
+                themeAmbient: Theme.motion.ambient,
+                layers: Effects.layers.length,
+                onBattery: PowerState.onBattery,
+                fullscreen: HyprState.anyFullscreen
+            });
+        }
+        function setMode(mode: string): void {
+            PrefsState.setAmbientMode(mode);
+        }
+        function setReduceMotion(v: string): void {
+            PrefsState.setReduceMotion(v === "on" || v === "true" || v === "1");
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/modules/ambient/AmbientLayer.qml
+++ b/modules/rice/runtime/quickshell/modules/ambient/AmbientLayer.qml
@@ -1,0 +1,90 @@
+import Quickshell
+import Quickshell.Wayland
+import QtQuick
+import "../../core"
+import "../../components/effects"
+
+// ── AmbientLayer ──────────────────────────────────────────────
+// Per-monitor atmosphere surface (D-021): mounts the theme's
+// resolved effect layers (core/Effects) between the wallpaper and
+// application windows. Input-transparent (empty mask) and mapped
+// only while the governor says so — when ambient is off the window
+// is unmapped and the Loader unloaded, so the steady-state cost is
+// exactly zero (motion-contract budget).
+
+PanelWindow {
+    id: layerWin
+
+    required property var modelData
+    screen: modelData
+
+    visible: ShellState.ambientActive && Effects.layers.length > 0
+
+    WlrLayershell.namespace: "rice-ambient"
+    WlrLayershell.layer: WlrLayer.Bottom
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+
+    anchors {
+        top: true
+        bottom: true
+        left: true
+        right: true
+    }
+    exclusionMode: ExclusionMode.Ignore
+    color: "transparent"
+
+    // Empty input region: every event passes through to the desktop.
+    mask: Region {}
+
+    Loader {
+        anchors.fill: parent
+        active: layerWin.visible
+
+        sourceComponent: Item {
+            Repeater {
+                model: Effects.layers
+
+                Loader {
+                    id: effectMount
+
+                    required property var modelData
+
+                    anchors.fill: parent
+                    sourceComponent: modelData.type === "fog" ? fogComponent
+                        : modelData.type === "particles" ? particleComponent
+                        : modelData.type === "vignette" ? vignetteComponent
+                        : null
+
+                    onLoaded: {
+                        item.tint = modelData.tint;
+                        item.strength = modelData.strength;
+                        if (modelData.type === "fog") {
+                            item.speed = modelData.speed;
+                            item.band = modelData.band;
+                        } else if (modelData.type === "particles") {
+                            item.speed = modelData.speed;
+                            item.count = modelData.count;
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: fogComponent
+                FogLayer {
+                    running: ShellState.ambientActive
+                }
+            }
+            Component {
+                id: particleComponent
+                ParticleField {
+                    running: ShellState.ambientActive
+                }
+            }
+            Component {
+                id: vignetteComponent
+                VignetteLayer {}
+            }
+        }
+    }
+}

--- a/modules/rice/runtime/quickshell/modules/ambient/qmldir
+++ b/modules/rice/runtime/quickshell/modules/ambient/qmldir
@@ -1,0 +1,2 @@
+AmbientController 1.0 AmbientController.qml
+AmbientLayer 1.0 AmbientLayer.qml

--- a/modules/rice/runtime/quickshell/modules/bar/TopBar.qml
+++ b/modules/rice/runtime/quickshell/modules/bar/TopBar.qml
@@ -107,6 +107,15 @@ PanelWindow {
         anchors.leftMargin: Theme.metrics.space.lg
         anchors.rightMargin: Theme.metrics.space.lg
 
+        // Startup reveal (D-022): the frame above is present and
+        // interactive immediately; only the contents fade in.
+        opacity: ShellState.awakened ? 1 : 0
+        Behavior on opacity {
+            MotionAnim {
+                spec: Motion.awaken
+            }
+        }
+
         Row {
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter

--- a/modules/rice/runtime/quickshell/modules/debug/DebugOverlay.qml
+++ b/modules/rice/runtime/quickshell/modules/debug/DebugOverlay.qml
@@ -96,7 +96,15 @@ PanelWindow {
                     ? ManifestLoader.meta.displayName + " (" + ManifestLoader.manifestPath + ")"
                     : "runtime defaults (no manifest)")
             }
-            DebugRow { text: "motion      " + (Motion.enabled ? "enabled" : "disabled") }
+            DebugRow {
+                text: "motion      " + (Motion.enabled ? "enabled" : "disabled")
+                    + (ShellState.reduceMotion ? " (reduce-motion)" : "")
+            }
+            DebugRow {
+                text: "ambient     " + (ShellState.ambientActive ? "active" : "off")
+                    + " · layers:" + Effects.layers.length
+                    + (HyprState.anyFullscreen ? " · fullscreen" : "")
+            }
             DebugRow { text: "overlay fps " + debug.fps }
             DebugRow { text: "" }
             DebugRow {

--- a/modules/rice/runtime/quickshell/services/hypr/HyprState.qml
+++ b/modules/rice/runtime/quickshell/services/hypr/HyprState.qml
@@ -1,6 +1,7 @@
 pragma Singleton
 import QtQuick
 import Quickshell.Hyprland
+import Quickshell.Wayland
 
 // ── HyprState — REAL (partial) ────────────────────────────────
 // Compositor state via Quickshell's native Hyprland binding
@@ -9,11 +10,18 @@ import Quickshell.Hyprland
 // window title) by porting from the legacy tree.
 //
 //   state:    available, focusedScreenName ("" when unknown),
-//             activeWorkspace (id)
+//             activeWorkspace (id), anyFullscreen
 //   commands: switchWorkspace(id)
 //
 // Focused output is exposed by NAME (matches ShellScreen.name);
 // HyprlandMonitor.screen is not reliable on this Quickshell version.
+//
+// anyFullscreen comes from the Wayland foreign-toplevel protocol
+// (compositor-agnostic; the Hyprland module exposes no fullscreen
+// fact). Per-toplevel `fullscreen` is not a model role, so the
+// Instantiator below attaches a watcher per toplevel and recounts
+// on change — event-driven, zero polling. Screen-agnostic for now:
+// per-monitor granularity waits for a consumer that needs it.
 
 Item {
     id: hypr
@@ -23,7 +31,35 @@ Item {
     readonly property string focusedScreenName: Hyprland.focusedMonitor ? Hyprland.focusedMonitor.name : ""
     readonly property int activeWorkspace: Hyprland.focusedMonitor?.activeWorkspace?.id ?? 1
 
+    property int _fullscreenCount: 0
+    readonly property bool anyFullscreen: _fullscreenCount > 0
+
     function switchWorkspace(id) {
         Hyprland.dispatch("workspace " + id);
+    }
+
+    function _recountFullscreen() {
+        const vals = ToplevelManager.toplevels.values;
+        let n = 0;
+        for (let i = 0; i < vals.length; i++)
+            if (vals[i].fullscreen)
+                n++;
+        hypr._fullscreenCount = n;
+    }
+
+    Instantiator {
+        model: ToplevelManager.toplevels
+
+        delegate: QtObject {
+            required property var modelData
+
+            readonly property bool fs: modelData.fullscreen ?? false
+
+            onFsChanged: hypr._recountFullscreen()
+            Component.onCompleted: hypr._recountFullscreen()
+            // Deferred: at destruction time the model still lists
+            // the departing toplevel.
+            Component.onDestruction: Qt.callLater(hypr._recountFullscreen)
+        }
     }
 }

--- a/modules/rice/runtime/quickshell/services/prefs/PrefsState.qml
+++ b/modules/rice/runtime/quickshell/services/prefs/PrefsState.qml
@@ -5,16 +5,18 @@ import Quickshell.Io
 
 // ── PrefsState — REAL ─────────────────────────────────────────
 // Sole WRITER of $XDG_STATE_HOME/rice/prefs.json (D-019). Durable
-// user drift that is not theme data and not system state — today:
-// last-used wallpaper per theme. rice-switch READS the file at
-// switch time; nothing else touches it.
+// user drift that is not theme data and not system state: last-used
+// wallpaper per theme, plus global motion prefs (D-021/D-022).
+// rice-switch READS the file at switch time; nothing else touches it.
 //
 // Theme-blind by layer rule (services never import core): callers
 // pass the theme name as an opaque key — the module-layer
 // WallpaperCommands supplies Theme.activeName.
 //
-//   state:    available, lastWallpaper(theme)
-//   commands: recordWallpaper(theme, path)
+//   state:    available, lastWallpaper(theme),
+//             reduceMotion, ambientMode ("auto" | "off")
+//   commands: recordWallpaper(theme, path),
+//             setReduceMotion(on), setAmbientMode(mode)
 
 Item {
     id: prefs
@@ -31,6 +33,33 @@ Item {
 
     function lastWallpaper(theme) {
         return (_data.wallpapers ?? {})[theme] ?? "";
+    }
+
+    // Motion prefs (D-021/D-022). Read by modules/ambient/
+    // AmbientController, which pushes them onto ShellState.
+    readonly property bool reduceMotion: (_data.motion ?? {}).reduce ?? false
+    readonly property string ambientMode: (_data.motion ?? {}).ambient ?? "auto"
+
+    function setReduceMotion(on) {
+        _writeMotion("reduce", !!on);
+    }
+
+    function setAmbientMode(mode) {
+        if (mode !== "auto" && mode !== "off") {
+            console.warn("PrefsState: ambient mode must be 'auto' or 'off', got", mode);
+            return;
+        }
+        _writeMotion("ambient", mode);
+    }
+
+    function _writeMotion(key, value) {
+        if (((_data.motion ?? {})[key] ?? null) === value)
+            return;
+        const next = JSON.parse(JSON.stringify(_data));
+        next.motion = next.motion ?? {};
+        next.motion[key] = value;
+        prefs._data = next;
+        file.setText(JSON.stringify(next, null, 2) + "\n");
     }
 
     function recordWallpaper(theme, path) {

--- a/modules/rice/runtime/quickshell/shell.qml
+++ b/modules/rice/runtime/quickshell/shell.qml
@@ -1,4 +1,5 @@
 import Quickshell
+import "./modules/ambient"
 import "./modules/bar"
 import "./modules/launcher"
 import "./modules/dashboard"
@@ -18,6 +19,13 @@ ShellRoot {
     NotificationIpc {}
 
     WallpaperIpc {}
+
+    AmbientController {}
+
+    Variants {
+        model: Quickshell.screens
+        AmbientLayer {}
+    }
 
     Variants {
         model: Quickshell.screens

--- a/modules/rice/themes/lotm/_theme.nix
+++ b/modules/rice/themes/lotm/_theme.nix
@@ -83,9 +83,32 @@ in
         base = 280;
         slow = 400;
         overlay = 120;
+        # Reserved for infrequent, deliberate moments (D-022).
+        ceremonial = 700;
       };
+      # Named curve specs (contracts/motion-contract.md): unhurried
+      # entries, sharper exits — a candlelit tempo.
+      easings = {
+        standard = "OutCubic";
+        enter = "OutQuint";
+        exit = "InCubic";
+        emphasis = "InOutBack";
+      };
+      # Opt into the ambient atmosphere tier (D-021); the runtime
+      # governor still pauses it on battery/fullscreen/reduce-motion.
+      ambient = true;
       enabled = true;
     };
+
+    # Ambient atmosphere (D-021): gray fog hugging the desktop floor,
+    # ember motes drifting up, a candlelit vignette. Tints are color
+    # token refs (L-005) — fog wears the fog-blue accent, embers the
+    # antique gold.
+    effects.layers = [
+      { type = "fog"; tint = "accent.secondary"; opacity = 0.10; speed = 1.0; band = "bottom"; }
+      { type = "particles"; tint = "accent.primary"; opacity = 0.30; count = 9; speed = 1.0; }
+      { type = "vignette"; tint = "bg.sunken"; opacity = 0.25; }
+    ];
   };
 
   assets = {


### PR DESCRIPTION
Ambient effects engine: optional closed-core tokens.effects validated at build (types fog/particles/vignette, tints are token refs per L-005), core/Effects as sole reader with structural budgets, theme-neutral T1 primitives under components/effects, per-monitor AmbientLayer on the bottom layer-shell (input-transparent, unloaded when paused — ambient-off steady state measured 0.0% CPU). Run/pause policy lives once in modules/ambient/AmbientController, pushing ShellState flags from prefs + battery + fullscreen (new HyprState.anyFullscreen via foreign-toplevel).

Motion v2: manifest easing names finally resolved (warn-and-default), optional durations.ceremonial, reduce-motion pref (PrefsState motion block) folded into Motion.enabled, awaken spec for the bar's startup reveal.

LOTM opts in as pure data: easings, ceremonial=700, ambient=true, fog + ember motes + vignette. Cyberpunk unaffected (defaults fill in).