### PR TITLE
feat(mugge): update mugge and nixpkgs, enable mugge-chat on hosts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
       },
       "locked": {
-        "lastModified": 1783418232,
-        "narHash": "sha256-91/DCbaLIVgtXsAbbBrttmvWrO0YF2TyFVoOEXeo29Q=",
+        "lastModified": 1783430352,
+        "narHash": "sha256-qSTuEx3CpDHUGLsnPrZq6XU417XRi848skoh3mUhNdw=",
         "owner": "HNIKT-Tjenesteutvikling-Systemutvikling",
         "repo": "mugge",
-        "rev": "ac55b15d5088f5d55428870cc7bba700c9042723",
+        "rev": "5972a9d29026a094e24988a4b08267f83afdc86a",
         "type": "github"
       },
       "original": {
@@ -1188,11 +1188,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1750215678,
-        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
       },
       "locked": {
-        "lastModified": 1783430352,
-        "narHash": "sha256-qSTuEx3CpDHUGLsnPrZq6XU417XRi848skoh3mUhNdw=",
+        "lastModified": 1783445364,
+        "narHash": "sha256-+A63cM1Ofo0zlbfhr4199wrrsBDLt2mmbQap9zDiWsg=",
         "owner": "HNIKT-Tjenesteutvikling-Systemutvikling",
         "repo": "mugge",
-        "rev": "5972a9d29026a094e24988a4b08267f83afdc86a",
+        "rev": "298cea933361e50027c0a45d163b5b8e62c81c97",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
       },
       "locked": {
-        "lastModified": 1783445364,
-        "narHash": "sha256-+A63cM1Ofo0zlbfhr4199wrrsBDLt2mmbQap9zDiWsg=",
+        "lastModified": 1783501606,
+        "narHash": "sha256-bky83Jvhb8NdgGkUg95siK/TJR0mR0Rn5pD8tmS0x08=",
         "owner": "HNIKT-Tjenesteutvikling-Systemutvikling",
         "repo": "mugge",
-        "rev": "298cea933361e50027c0a45d163b5b8e62c81c97",
+        "rev": "5c1448d897b2a4cd3fc50d69c3982101969c2927",
         "type": "github"
       },
       "original": {

--- a/modules/programs/mugge.nix
+++ b/modules/programs/mugge.nix
@@ -11,14 +11,15 @@ _: {
       muggeHosts = [
         "shitbox"
       ];
+      onMuggeHost = lib.elem osConfig.networking.hostName muggeHosts;
     in
     {
-      home.packages = lib.mkIf (lib.elem osConfig.networking.hostName muggeHosts) [
+      imports = [ inputs.mugge.homeManagerModules.default ];
+
+      services.mugge-chat.enable = onMuggeHost;
+
+      home.packages = lib.mkIf onMuggeHost [
         muggePkgs.mugge-azure
       ];
-
-      programs.fish.shellAliases = {
-        mugge = "mugge-azure";
-      };
     };
 }


### PR DESCRIPTION
- Update mugge and nixpkgs sources in flake.lock
- Refactor mugge.nix to use onMuggeHost variable
- Enable services.mugge-chat on mugge hosts
- Import mugge homeManager module and clean up shell aliases